### PR TITLE
Add backend unit tests and fix certificate test mock

### DIFF
--- a/backend/test/internal/certificate.test.js
+++ b/backend/test/internal/certificate.test.js
@@ -44,8 +44,8 @@ vi.mock("node:https", () => {
 // Mock fs
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal();
-	return {
-		...actual,
+	const mockFs = {
+		...actual.default,
 		mkdirSync: vi.fn(),
 		writeFileSync: vi.fn(),
 		unlinkSync: vi.fn(),
@@ -68,6 +68,12 @@ vi.mock("node:fs", async (importOriginal) => {
 			}
 			return Buffer.from("");
 		}),
+	};
+
+	return {
+		...actual,
+		default: mockFs,
+		...mockFs,
 	};
 });
 

--- a/backend/test/internal/nginx.test.js
+++ b/backend/test/internal/nginx.test.js
@@ -92,7 +92,7 @@ describe('backend/internal/nginx.js', () => {
 
     describe('configure', () => {
         it('should configure nginx successfully', async () => {
-            const result = await internalNginx.configure(mockModel, 'proxy-host', mockHost);
+            await internalNginx.configure(mockModel, 'proxy-host', mockHost);
 
             // Verify backup
             expect(fs.promises.copyFile).toHaveBeenCalled();

--- a/backend/test/internal/nginx.test.js
+++ b/backend/test/internal/nginx.test.js
@@ -1,163 +1,167 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import internalNginx from '../../internal/nginx.js';
-import utils from '../../lib/utils.js';
-import internalAnubis from '../../internal/anubis.js';
-import fs from 'node:fs';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import internalNginx from "../../internal/nginx.js";
+import utils from "../../lib/utils.js";
+import internalAnubis from "../../internal/anubis.js";
+import fs from "node:fs";
 
 // Mock utils
-vi.mock('../../lib/utils.js', () => ({
-    default: {
-        execFile: vi.fn(),
-        getRenderEngine: vi.fn(),
-        writeHash: vi.fn(),
-        getFileFriendlyHostType: vi.fn((t) => t.replace(/-/g, '_')),
-    }
+vi.mock("../../lib/utils.js", () => ({
+	default: {
+		execFile: vi.fn(),
+		getRenderEngine: vi.fn(),
+		writeHash: vi.fn(),
+		getFileFriendlyHostType: vi.fn((t) => t.replace(/-/g, "_")),
+	},
 }));
 
 // Mock logger
-vi.mock('../../logger.js', () => ({
-    nginx: {
-        info: vi.fn(),
-        error: vi.fn(),
-        warn: vi.fn(),
-    },
-    debug: vi.fn(),
-    global: {},
+vi.mock("../../logger.js", () => ({
+	nginx: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+	},
+	debug: vi.fn(),
+	global: {},
 }));
 
 // Mock anubis
-vi.mock('../../internal/anubis.js', () => ({
-    default: {
-        generatePolicy: vi.fn(),
-    }
+vi.mock("../../internal/anubis.js", () => ({
+	default: {
+		generatePolicy: vi.fn(),
+	},
 }));
 
 // Mock fs
-vi.mock('node:fs', () => ({
-    default: {
-        promises: {
-            writeFile: vi.fn(),
-            unlink: vi.fn(),
-            rename: vi.fn(),
-            copyFile: vi.fn(),
-            access: vi.fn(),
-        },
-    }
+vi.mock("node:fs", () => ({
+	default: {
+		promises: {
+			writeFile: vi.fn(),
+			unlink: vi.fn(),
+			rename: vi.fn(),
+			copyFile: vi.fn(),
+			access: vi.fn(),
+		},
+	},
 }));
 
-describe('backend/internal/nginx.js', () => {
-    let mockModel;
-    let mockQueryBuilder;
-    let mockHost;
+describe("backend/internal/nginx.js", () => {
+	let mockModel;
+	let mockQueryBuilder;
+	let mockHost;
 
-    beforeEach(() => {
-        vi.clearAllMocks();
+	beforeEach(() => {
+		vi.clearAllMocks();
 
-        mockQueryBuilder = {
-            where: vi.fn().mockReturnThis(),
-            patch: vi.fn().mockResolvedValue(1),
-        };
+		mockQueryBuilder = {
+			where: vi.fn().mockReturnThis(),
+			patch: vi.fn().mockResolvedValue(1),
+		};
 
-        mockModel = {
-            query: vi.fn(() => mockQueryBuilder),
-        };
+		mockModel = {
+			query: vi.fn(() => mockQueryBuilder),
+		};
 
-        mockHost = {
-            id: 1,
-            domain_names: ['example.com'],
-            forward_scheme: 'http',
-            forward_host: '1.2.3.4',
-            forward_port: 80,
-            caching_enabled: false,
-            block_exploits: false,
-            allow_websocket_upgrade: false,
-            access_list_id: 0,
-            certificate_id: 0,
-            ssl_forced: false,
-            hsts_enabled: false,
-            hsts_subdomains: false,
-            http2_support: false,
-            meta: {},
-        };
+		mockHost = {
+			id: 1,
+			domain_names: ["example.com"],
+			forward_scheme: "http",
+			forward_host: "1.2.3.4",
+			forward_port: 80,
+			caching_enabled: false,
+			block_exploits: false,
+			allow_websocket_upgrade: false,
+			access_list_id: 0,
+			certificate_id: 0,
+			ssl_forced: false,
+			hsts_enabled: false,
+			hsts_subdomains: false,
+			http2_support: false,
+			meta: {},
+		};
 
-        // Mock render engine
-        utils.getRenderEngine.mockReturnValue({
-            renderFile: vi.fn().mockResolvedValue('server { ... }'),
-            registerFilter: vi.fn(),
-        });
+		// Mock render engine
+		utils.getRenderEngine.mockReturnValue({
+			renderFile: vi.fn().mockResolvedValue("server { ... }"),
+			registerFilter: vi.fn(),
+		});
 
-        // Mock execFile success by default
-        utils.execFile.mockResolvedValue('ok');
-    });
+		// Mock execFile success by default
+		utils.execFile.mockResolvedValue("ok");
+	});
 
-    describe('configure', () => {
-        it('should configure nginx successfully', async () => {
-            await internalNginx.configure(mockModel, 'proxy-host', mockHost);
+	describe("configure", () => {
+		it("should configure nginx successfully", async () => {
+			await internalNginx.configure(mockModel, "proxy-host", mockHost);
 
-            // Verify backup
-            expect(fs.promises.copyFile).toHaveBeenCalled();
-            // Verify generate config
-            expect(utils.getRenderEngine().renderFile).toHaveBeenCalled();
-            expect(fs.promises.writeFile).toHaveBeenCalled();
-            // Verify test
-            expect(utils.execFile).toHaveBeenCalledWith('nginx', ['-tq']);
-            // Verify delete backup
-            expect(internalAnubis.generatePolicy).toHaveBeenCalled();
-            // Verify meta update
-            expect(mockModel.query).toHaveBeenCalled();
-            expect(mockQueryBuilder.patch).toHaveBeenCalledWith(expect.objectContaining({
-                meta: expect.objectContaining({ nginx_online: true })
-            }));
+			// Verify backup
+			expect(fs.promises.copyFile).toHaveBeenCalled();
+			// Verify generate config
+			expect(utils.getRenderEngine().renderFile).toHaveBeenCalled();
+			expect(fs.promises.writeFile).toHaveBeenCalled();
+			// Verify test
+			expect(utils.execFile).toHaveBeenCalledWith("nginx", ["-tq"]);
+			// Verify delete backup
+			expect(internalAnubis.generatePolicy).toHaveBeenCalled();
+			// Verify meta update
+			expect(mockModel.query).toHaveBeenCalled();
+			expect(mockQueryBuilder.patch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					meta: expect.objectContaining({ nginx_online: true }),
+				}),
+			);
 
-            // Reload called?
-            expect(utils.execFile).toHaveBeenCalledWith('nginx', ['-s', 'reload']);
-        });
+			// Reload called?
+			expect(utils.execFile).toHaveBeenCalledWith("nginx", ["-s", "reload"]);
+		});
 
-        it('should rollback on configuration failure', async () => {
-            // Mock test failure
-            let failedOnce = false;
-            utils.execFile.mockImplementation((cmd, args) => {
-                if (cmd === 'nginx' && args && args[0] === '-tq' && !failedOnce) {
-                    failedOnce = true;
-                    return Promise.reject(new Error('nginx test failed'));
-                }
-                return Promise.resolve('ok');
-            });
+		it("should rollback on configuration failure", async () => {
+			// Mock test failure
+			let failedOnce = false;
+			utils.execFile.mockImplementation((cmd, args) => {
+				if (cmd === "nginx" && args && args[0] === "-tq" && !failedOnce) {
+					failedOnce = true;
+					return Promise.reject(new Error("nginx test failed"));
+				}
+				return Promise.resolve("ok");
+			});
 
-            // Mock rename (renameConfigAsError)
-            fs.promises.rename.mockResolvedValue();
+			// Mock rename (renameConfigAsError)
+			fs.promises.rename.mockResolvedValue();
 
-            await internalNginx.configure(mockModel, 'proxy-host', mockHost);
+			await internalNginx.configure(mockModel, "proxy-host", mockHost);
 
-            // Verify rollback
-            expect(fs.promises.rename).toHaveBeenCalledTimes(2); // once to .err, once to restore .bak
+			// Verify rollback
+			expect(fs.promises.rename).toHaveBeenCalledTimes(2); // once to .err, once to restore .bak
 
-            // Verify meta update with error
-            expect(mockQueryBuilder.patch).toHaveBeenCalledWith(expect.objectContaining({
-                meta: expect.objectContaining({ nginx_online: false })
-            }));
-        });
-    });
+			// Verify meta update with error
+			expect(mockQueryBuilder.patch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					meta: expect.objectContaining({ nginx_online: false }),
+				}),
+			);
+		});
+	});
 
-    describe('test', () => {
-        it('should call nginx -tq', async () => {
-            await internalNginx.test();
-            expect(utils.execFile).toHaveBeenCalledWith('nginx', ['-tq']);
-        });
-    });
+	describe("test", () => {
+		it("should call nginx -tq", async () => {
+			await internalNginx.test();
+			expect(utils.execFile).toHaveBeenCalledWith("nginx", ["-tq"]);
+		});
+	});
 
-    describe('reload', () => {
-        it('should call nginx -s reload', async () => {
-            await internalNginx.reload();
-            expect(utils.execFile).toHaveBeenCalledWith('nginx', ['-s', 'reload']);
-        });
-    });
+	describe("reload", () => {
+		it("should call nginx -s reload", async () => {
+			await internalNginx.reload();
+			expect(utils.execFile).toHaveBeenCalledWith("nginx", ["-s", "reload"]);
+		});
+	});
 
-    describe('deleteConfig', () => {
-        it('should delete config and .err files', async () => {
-            fs.promises.access.mockResolvedValue(); // file exists
-            await internalNginx.deleteConfig('proxy-host', mockHost);
-            expect(fs.promises.unlink).toHaveBeenCalledTimes(2);
-        });
-    });
+	describe("deleteConfig", () => {
+		it("should delete config and .err files", async () => {
+			fs.promises.access.mockResolvedValue(); // file exists
+			await internalNginx.deleteConfig("proxy-host", mockHost);
+			expect(fs.promises.unlink).toHaveBeenCalledTimes(2);
+		});
+	});
 });

--- a/backend/test/internal/nginx.test.js
+++ b/backend/test/internal/nginx.test.js
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import internalNginx from '../../internal/nginx.js';
+import utils from '../../lib/utils.js';
+import internalAnubis from '../../internal/anubis.js';
+import fs from 'node:fs';
+
+// Mock utils
+vi.mock('../../lib/utils.js', () => ({
+    default: {
+        execFile: vi.fn(),
+        getRenderEngine: vi.fn(),
+        writeHash: vi.fn(),
+        getFileFriendlyHostType: vi.fn((t) => t.replace(/-/g, '_')),
+    }
+}));
+
+// Mock logger
+vi.mock('../../logger.js', () => ({
+    nginx: {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+    },
+    debug: vi.fn(),
+    global: {},
+}));
+
+// Mock anubis
+vi.mock('../../internal/anubis.js', () => ({
+    default: {
+        generatePolicy: vi.fn(),
+    }
+}));
+
+// Mock fs
+vi.mock('node:fs', () => ({
+    default: {
+        promises: {
+            writeFile: vi.fn(),
+            unlink: vi.fn(),
+            rename: vi.fn(),
+            copyFile: vi.fn(),
+            access: vi.fn(),
+        },
+    }
+}));
+
+describe('backend/internal/nginx.js', () => {
+    let mockModel;
+    let mockQueryBuilder;
+    let mockHost;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockQueryBuilder = {
+            where: vi.fn().mockReturnThis(),
+            patch: vi.fn().mockResolvedValue(1),
+        };
+
+        mockModel = {
+            query: vi.fn(() => mockQueryBuilder),
+        };
+
+        mockHost = {
+            id: 1,
+            domain_names: ['example.com'],
+            forward_scheme: 'http',
+            forward_host: '1.2.3.4',
+            forward_port: 80,
+            caching_enabled: false,
+            block_exploits: false,
+            allow_websocket_upgrade: false,
+            access_list_id: 0,
+            certificate_id: 0,
+            ssl_forced: false,
+            hsts_enabled: false,
+            hsts_subdomains: false,
+            http2_support: false,
+            meta: {},
+        };
+
+        // Mock render engine
+        utils.getRenderEngine.mockReturnValue({
+            renderFile: vi.fn().mockResolvedValue('server { ... }'),
+            registerFilter: vi.fn(),
+        });
+
+        // Mock execFile success by default
+        utils.execFile.mockResolvedValue('ok');
+    });
+
+    describe('configure', () => {
+        it('should configure nginx successfully', async () => {
+            const result = await internalNginx.configure(mockModel, 'proxy-host', mockHost);
+
+            // Verify backup
+            expect(fs.promises.copyFile).toHaveBeenCalled();
+            // Verify generate config
+            expect(utils.getRenderEngine().renderFile).toHaveBeenCalled();
+            expect(fs.promises.writeFile).toHaveBeenCalled();
+            // Verify test
+            expect(utils.execFile).toHaveBeenCalledWith('nginx', ['-tq']);
+            // Verify delete backup
+            expect(internalAnubis.generatePolicy).toHaveBeenCalled();
+            // Verify meta update
+            expect(mockModel.query).toHaveBeenCalled();
+            expect(mockQueryBuilder.patch).toHaveBeenCalledWith(expect.objectContaining({
+                meta: expect.objectContaining({ nginx_online: true })
+            }));
+
+            // Reload called?
+            expect(utils.execFile).toHaveBeenCalledWith('nginx', ['-s', 'reload']);
+        });
+
+        it('should rollback on configuration failure', async () => {
+            // Mock test failure
+            let failedOnce = false;
+            utils.execFile.mockImplementation((cmd, args) => {
+                if (cmd === 'nginx' && args && args[0] === '-tq' && !failedOnce) {
+                    failedOnce = true;
+                    return Promise.reject(new Error('nginx test failed'));
+                }
+                return Promise.resolve('ok');
+            });
+
+            // Mock rename (renameConfigAsError)
+            fs.promises.rename.mockResolvedValue();
+
+            await internalNginx.configure(mockModel, 'proxy-host', mockHost);
+
+            // Verify rollback
+            expect(fs.promises.rename).toHaveBeenCalledTimes(2); // once to .err, once to restore .bak
+
+            // Verify meta update with error
+            expect(mockQueryBuilder.patch).toHaveBeenCalledWith(expect.objectContaining({
+                meta: expect.objectContaining({ nginx_online: false })
+            }));
+        });
+    });
+
+    describe('test', () => {
+        it('should call nginx -tq', async () => {
+            await internalNginx.test();
+            expect(utils.execFile).toHaveBeenCalledWith('nginx', ['-tq']);
+        });
+    });
+
+    describe('reload', () => {
+        it('should call nginx -s reload', async () => {
+            await internalNginx.reload();
+            expect(utils.execFile).toHaveBeenCalledWith('nginx', ['-s', 'reload']);
+        });
+    });
+
+    describe('deleteConfig', () => {
+        it('should delete config and .err files', async () => {
+            fs.promises.access.mockResolvedValue(); // file exists
+            await internalNginx.deleteConfig('proxy-host', mockHost);
+            expect(fs.promises.unlink).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/backend/test/internal/token.test.js
+++ b/backend/test/internal/token.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import internalToken from '../../internal/token.js';
+import errs from '../../lib/error.js';
+import userModel from '../../models/user.js';
+import authModel from '../../models/auth.js';
+import TokenModel from '../../models/token.js';
+
+// Mock dependencies
+vi.mock('../../models/user.js', () => {
+    return {
+        default: {
+            query: vi.fn(),
+        }
+    };
+});
+
+vi.mock('../../models/auth.js', () => {
+    return {
+        default: {
+            query: vi.fn(),
+        }
+    };
+});
+
+vi.mock('../../models/token.js', () => {
+    return {
+        default: vi.fn(() => ({
+            create: vi.fn(),
+        }))
+    };
+});
+
+vi.mock('bcryptjs', () => ({
+    default: {
+        compare: vi.fn().mockResolvedValue(true),
+    }
+}));
+
+describe('backend/internal/token.js', () => {
+    let mockUserQuery;
+    let mockAuthQuery;
+    let mockTokenInstance;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        // Setup User mock
+        mockUserQuery = {
+            where: vi.fn().mockReturnThis(),
+            andWhere: vi.fn().mockReturnThis(),
+            first: vi.fn(),
+        };
+        userModel.query.mockReturnValue(mockUserQuery);
+
+        // Setup Auth mock
+        mockAuthQuery = {
+            where: vi.fn().mockReturnThis(),
+            first: vi.fn(),
+        };
+        authModel.query.mockReturnValue(mockAuthQuery);
+
+        // Setup Token mock
+        mockTokenInstance = {
+            create: vi.fn(),
+        };
+        TokenModel.mockReturnValue(mockTokenInstance);
+    });
+
+    describe('getTokenFromEmail', () => {
+        it('should return token for valid credentials', async () => {
+            const user = { id: 1, email: 'test@example.com', roles: ['user'], is_deleted: 0, is_disabled: 0 };
+            const auth = { verifyPassword: vi.fn().mockResolvedValue(true) };
+            const token = { token: 'jwt-token' };
+
+            mockUserQuery.first.mockResolvedValue(user);
+            mockAuthQuery.first.mockResolvedValue(auth);
+            mockTokenInstance.create.mockResolvedValue(token);
+
+            const result = await internalToken.getTokenFromEmail({
+                identity: 'test@example.com',
+                secret: 'password'
+            });
+
+            expect(result.token).toBe('jwt-token');
+            expect(result.user.email).toBe('test@example.com');
+        });
+
+        it('should throw AuthError for invalid user', async () => {
+            mockUserQuery.first.mockResolvedValue(null);
+
+            await expect(internalToken.getTokenFromEmail({
+                identity: 'test@example.com',
+                secret: 'password'
+            })).rejects.toThrow(errs.AuthError);
+        });
+
+        it('should throw AuthError for invalid password', async () => {
+            const user = { id: 1, email: 'test@example.com', roles: ['user'] };
+            const auth = { verifyPassword: vi.fn().mockResolvedValue(false) };
+
+            mockUserQuery.first.mockResolvedValue(user);
+            mockAuthQuery.first.mockResolvedValue(auth);
+
+            await expect(internalToken.getTokenFromEmail({
+                identity: 'test@example.com',
+                secret: 'password'
+            })).rejects.toThrow(errs.AuthError);
+        });
+    });
+
+    describe('getTokenFromUser', () => {
+        it('should return token for user object', async () => {
+            const user = { id: 1, email: 'test@example.com' };
+            const token = { token: 'jwt-token' };
+            mockTokenInstance.create.mockResolvedValue(token);
+
+            const result = await internalToken.getTokenFromUser(user);
+
+            expect(result.token).toBe('jwt-token');
+            expect(result.user).toEqual(user);
+        });
+    });
+});

--- a/backend/test/internal/token.test.js
+++ b/backend/test/internal/token.test.js
@@ -1,123 +1,127 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import internalToken from '../../internal/token.js';
-import errs from '../../lib/error.js';
-import userModel from '../../models/user.js';
-import authModel from '../../models/auth.js';
-import TokenModel from '../../models/token.js';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import internalToken from "../../internal/token.js";
+import errs from "../../lib/error.js";
+import userModel from "../../models/user.js";
+import authModel from "../../models/auth.js";
+import TokenModel from "../../models/token.js";
 
 // Mock dependencies
-vi.mock('../../models/user.js', () => {
-    return {
-        default: {
-            query: vi.fn(),
-        }
-    };
+vi.mock("../../models/user.js", () => {
+	return {
+		default: {
+			query: vi.fn(),
+		},
+	};
 });
 
-vi.mock('../../models/auth.js', () => {
-    return {
-        default: {
-            query: vi.fn(),
-        }
-    };
+vi.mock("../../models/auth.js", () => {
+	return {
+		default: {
+			query: vi.fn(),
+		},
+	};
 });
 
-vi.mock('../../models/token.js', () => {
-    return {
-        default: vi.fn(() => ({
-            create: vi.fn(),
-        }))
-    };
+vi.mock("../../models/token.js", () => {
+	return {
+		default: vi.fn(() => ({
+			create: vi.fn(),
+		})),
+	};
 });
 
-vi.mock('bcryptjs', () => ({
-    default: {
-        compare: vi.fn().mockResolvedValue(true),
-    }
+vi.mock("bcryptjs", () => ({
+	default: {
+		compare: vi.fn().mockResolvedValue(true),
+	},
 }));
 
-describe('backend/internal/token.js', () => {
-    let mockUserQuery;
-    let mockAuthQuery;
-    let mockTokenInstance;
+describe("backend/internal/token.js", () => {
+	let mockUserQuery;
+	let mockAuthQuery;
+	let mockTokenInstance;
 
-    beforeEach(() => {
-        vi.clearAllMocks();
+	beforeEach(() => {
+		vi.clearAllMocks();
 
-        // Setup User mock
-        mockUserQuery = {
-            where: vi.fn().mockReturnThis(),
-            andWhere: vi.fn().mockReturnThis(),
-            first: vi.fn(),
-        };
-        userModel.query.mockReturnValue(mockUserQuery);
+		// Setup User mock
+		mockUserQuery = {
+			where: vi.fn().mockReturnThis(),
+			andWhere: vi.fn().mockReturnThis(),
+			first: vi.fn(),
+		};
+		userModel.query.mockReturnValue(mockUserQuery);
 
-        // Setup Auth mock
-        mockAuthQuery = {
-            where: vi.fn().mockReturnThis(),
-            first: vi.fn(),
-        };
-        authModel.query.mockReturnValue(mockAuthQuery);
+		// Setup Auth mock
+		mockAuthQuery = {
+			where: vi.fn().mockReturnThis(),
+			first: vi.fn(),
+		};
+		authModel.query.mockReturnValue(mockAuthQuery);
 
-        // Setup Token mock
-        mockTokenInstance = {
-            create: vi.fn(),
-        };
-        TokenModel.mockReturnValue(mockTokenInstance);
-    });
+		// Setup Token mock
+		mockTokenInstance = {
+			create: vi.fn(),
+		};
+		TokenModel.mockReturnValue(mockTokenInstance);
+	});
 
-    describe('getTokenFromEmail', () => {
-        it('should return token for valid credentials', async () => {
-            const user = { id: 1, email: 'test@example.com', roles: ['user'], is_deleted: 0, is_disabled: 0 };
-            const auth = { verifyPassword: vi.fn().mockResolvedValue(true) };
-            const token = { token: 'jwt-token' };
+	describe("getTokenFromEmail", () => {
+		it("should return token for valid credentials", async () => {
+			const user = { id: 1, email: "test@example.com", roles: ["user"], is_deleted: 0, is_disabled: 0 };
+			const auth = { verifyPassword: vi.fn().mockResolvedValue(true) };
+			const token = { token: "jwt-token" };
 
-            mockUserQuery.first.mockResolvedValue(user);
-            mockAuthQuery.first.mockResolvedValue(auth);
-            mockTokenInstance.create.mockResolvedValue(token);
+			mockUserQuery.first.mockResolvedValue(user);
+			mockAuthQuery.first.mockResolvedValue(auth);
+			mockTokenInstance.create.mockResolvedValue(token);
 
-            const result = await internalToken.getTokenFromEmail({
-                identity: 'test@example.com',
-                secret: 'password'
-            });
+			const result = await internalToken.getTokenFromEmail({
+				identity: "test@example.com",
+				secret: "password",
+			});
 
-            expect(result.token).toBe('jwt-token');
-            expect(result.user.email).toBe('test@example.com');
-        });
+			expect(result.token).toBe("jwt-token");
+			expect(result.user.email).toBe("test@example.com");
+		});
 
-        it('should throw AuthError for invalid user', async () => {
-            mockUserQuery.first.mockResolvedValue(null);
+		it("should throw AuthError for invalid user", async () => {
+			mockUserQuery.first.mockResolvedValue(null);
 
-            await expect(internalToken.getTokenFromEmail({
-                identity: 'test@example.com',
-                secret: 'password'
-            })).rejects.toThrow(errs.AuthError);
-        });
+			await expect(
+				internalToken.getTokenFromEmail({
+					identity: "test@example.com",
+					secret: "password",
+				}),
+			).rejects.toThrow(errs.AuthError);
+		});
 
-        it('should throw AuthError for invalid password', async () => {
-            const user = { id: 1, email: 'test@example.com', roles: ['user'] };
-            const auth = { verifyPassword: vi.fn().mockResolvedValue(false) };
+		it("should throw AuthError for invalid password", async () => {
+			const user = { id: 1, email: "test@example.com", roles: ["user"] };
+			const auth = { verifyPassword: vi.fn().mockResolvedValue(false) };
 
-            mockUserQuery.first.mockResolvedValue(user);
-            mockAuthQuery.first.mockResolvedValue(auth);
+			mockUserQuery.first.mockResolvedValue(user);
+			mockAuthQuery.first.mockResolvedValue(auth);
 
-            await expect(internalToken.getTokenFromEmail({
-                identity: 'test@example.com',
-                secret: 'password'
-            })).rejects.toThrow(errs.AuthError);
-        });
-    });
+			await expect(
+				internalToken.getTokenFromEmail({
+					identity: "test@example.com",
+					secret: "password",
+				}),
+			).rejects.toThrow(errs.AuthError);
+		});
+	});
 
-    describe('getTokenFromUser', () => {
-        it('should return token for user object', async () => {
-            const user = { id: 1, email: 'test@example.com' };
-            const token = { token: 'jwt-token' };
-            mockTokenInstance.create.mockResolvedValue(token);
+	describe("getTokenFromUser", () => {
+		it("should return token for user object", async () => {
+			const user = { id: 1, email: "test@example.com" };
+			const token = { token: "jwt-token" };
+			mockTokenInstance.create.mockResolvedValue(token);
 
-            const result = await internalToken.getTokenFromUser(user);
+			const result = await internalToken.getTokenFromUser(user);
 
-            expect(result.token).toBe('jwt-token');
-            expect(result.user).toEqual(user);
-        });
-    });
+			expect(result.token).toBe("jwt-token");
+			expect(result.user).toEqual(user);
+		});
+	});
 });

--- a/backend/test/lib/encryption.test.js
+++ b/backend/test/lib/encryption.test.js
@@ -1,35 +1,35 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from "vitest";
 
 // Mock config.js before importing encryption.js
-vi.mock('../../lib/config.js', () => ({
-    getEncryptionKey: vi.fn(() => '000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f'), // 32 bytes in hex
+vi.mock("../../lib/config.js", () => ({
+	getEncryptionKey: vi.fn(() => "000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f"), // 32 bytes in hex
 }));
 
-import * as encryption from '../../lib/encryption.js';
+import * as encryption from "../../lib/encryption.js";
 
-describe('backend/lib/encryption.js', () => {
-    it('should encrypt and decrypt correctly', () => {
-        const text = 'Hello World';
-        const encrypted = encryption.encrypt(text);
-        expect(encrypted).not.toBe(text);
-        expect(encrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/); // format check
+describe("backend/lib/encryption.js", () => {
+	it("should encrypt and decrypt correctly", () => {
+		const text = "Hello World";
+		const encrypted = encryption.encrypt(text);
+		expect(encrypted).not.toBe(text);
+		expect(encrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/); // format check
 
-        const decrypted = encryption.decrypt(encrypted);
-        expect(decrypted).toBe(text);
-    });
+		const decrypted = encryption.decrypt(encrypted);
+		expect(decrypted).toBe(text);
+	});
 
-    it('should throw error for invalid encrypted format', () => {
-        expect(() => encryption.decrypt('invalid')).toThrow('Invalid encrypted text format');
-    });
+	it("should throw error for invalid encrypted format", () => {
+		expect(() => encryption.decrypt("invalid")).toThrow("Invalid encrypted text format");
+	});
 
-    it('should throw error when decrypting with corrupted data', () => {
-        const text = 'Secret';
-        const encrypted = encryption.encrypt(text);
-        const parts = encrypted.split(':');
-        // Modify the ciphertext
-        parts[1] = parts[1].split('').reverse().join('');
-        const corrupted = parts.join(':');
+	it("should throw error when decrypting with corrupted data", () => {
+		const text = "Secret";
+		const encrypted = encryption.encrypt(text);
+		const parts = encrypted.split(":");
+		// Modify the ciphertext
+		parts[1] = parts[1].split("").reverse().join("");
+		const corrupted = parts.join(":");
 
-        expect(() => encryption.decrypt(corrupted)).toThrow();
-    });
+		expect(() => encryption.decrypt(corrupted)).toThrow();
+	});
 });

--- a/backend/test/lib/encryption.test.js
+++ b/backend/test/lib/encryption.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock config.js before importing encryption.js
+vi.mock('../../lib/config.js', () => ({
+    getEncryptionKey: vi.fn(() => '000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f'), // 32 bytes in hex
+}));
+
+import * as encryption from '../../lib/encryption.js';
+
+describe('backend/lib/encryption.js', () => {
+    it('should encrypt and decrypt correctly', () => {
+        const text = 'Hello World';
+        const encrypted = encryption.encrypt(text);
+        expect(encrypted).not.toBe(text);
+        expect(encrypted).toMatch(/^[0-9a-f]+:[0-9a-f]+:[0-9a-f]+$/); // format check
+
+        const decrypted = encryption.decrypt(encrypted);
+        expect(decrypted).toBe(text);
+    });
+
+    it('should throw error for invalid encrypted format', () => {
+        expect(() => encryption.decrypt('invalid')).toThrow('Invalid encrypted text format');
+    });
+
+    it('should throw error when decrypting with corrupted data', () => {
+        const text = 'Secret';
+        const encrypted = encryption.encrypt(text);
+        const parts = encrypted.split(':');
+        // Modify the ciphertext
+        parts[1] = parts[1].split('').reverse().join('');
+        const corrupted = parts.join(':');
+
+        expect(() => encryption.decrypt(corrupted)).toThrow();
+    });
+});

--- a/backend/test/lib/error.test.js
+++ b/backend/test/lib/error.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import errs from '../../lib/error.js';
+
+describe('backend/lib/error.js', () => {
+    it('PermissionError should be configured correctly', () => {
+        const err = new errs.PermissionError('msg');
+        expect(err).toBeInstanceOf(Error);
+        expect(err.name).toBe('PermissionError');
+        expect(err.status).toBe(403);
+        expect(err.public).toBe(true);
+        expect(err.message).toBe('msg');
+    });
+
+    it('ItemNotFoundError should be configured correctly', () => {
+        const err = new errs.ItemNotFoundError('123');
+        expect(err.name).toBe('ItemNotFoundError');
+        expect(err.status).toBe(404);
+        expect(err.public).toBe(true);
+        expect(err.message).toContain('123');
+    });
+
+    it('AuthError should be configured correctly', () => {
+        const err = new errs.AuthError('msg', 'i18n_key');
+        expect(err.name).toBe('AuthError');
+        expect(err.status).toBe(400);
+        expect(err.public).toBe(true);
+        expect(err.message_i18n).toBe('i18n_key');
+    });
+
+    it('InternalError should be configured correctly', () => {
+        const err = new errs.InternalError('msg');
+        expect(err.name).toBe('InternalError');
+        expect(err.status).toBe(500);
+        expect(err.public).toBe(false);
+    });
+
+    it('InternalValidationError should be configured correctly', () => {
+        const err = new errs.InternalValidationError('msg');
+        expect(err.name).toBe('InternalValidationError');
+        expect(err.status).toBe(400);
+        expect(err.public).toBe(false);
+    });
+
+    it('ConfigurationError should be configured correctly', () => {
+        const err = new errs.ConfigurationError('msg');
+        expect(err.name).toBe('ConfigurationError');
+        expect(err.status).toBe(400);
+        expect(err.public).toBe(true);
+    });
+
+    it('CacheError should be configured correctly', () => {
+        const err = new errs.CacheError('msg');
+        expect(err.name).toBe('CacheError');
+        expect(err.status).toBe(500);
+        expect(err.public).toBe(false);
+    });
+
+    it('ValidationError should be configured correctly', () => {
+        const err = new errs.ValidationError('msg');
+        expect(err.name).toBe('ValidationError');
+        expect(err.status).toBe(400);
+        expect(err.public).toBe(true);
+    });
+
+    it('AssertionFailedError should be configured correctly', () => {
+        const err = new errs.AssertionFailedError('msg');
+        expect(err.name).toBe('AssertionFailedError');
+        expect(err.status).toBe(400);
+        expect(err.public).toBe(false);
+    });
+
+    it('UnauthorizedError should be configured correctly', () => {
+        const err = new errs.UnauthorizedError('msg');
+        expect(err.name).toBe('UnauthorizedError');
+        expect(err.status).toBe(401);
+        expect(err.public).toBe(true);
+    });
+
+    it('CommandError should be configured correctly', () => {
+        const err = new errs.CommandError('stderr output', 127);
+        expect(err.name).toBe('CommandError');
+        expect(err.message).toBe('stderr output');
+        expect(err.code).toBe(127);
+        expect(err.public).toBe(false);
+    });
+});

--- a/backend/test/lib/error.test.js
+++ b/backend/test/lib/error.test.js
@@ -1,86 +1,86 @@
-import { describe, it, expect } from 'vitest';
-import errs from '../../lib/error.js';
+import { describe, it, expect } from "vitest";
+import errs from "../../lib/error.js";
 
-describe('backend/lib/error.js', () => {
-    it('PermissionError should be configured correctly', () => {
-        const err = new errs.PermissionError('msg');
-        expect(err).toBeInstanceOf(Error);
-        expect(err.name).toBe('PermissionError');
-        expect(err.status).toBe(403);
-        expect(err.public).toBe(true);
-        expect(err.message).toBe('msg');
-    });
+describe("backend/lib/error.js", () => {
+	it("PermissionError should be configured correctly", () => {
+		const err = new errs.PermissionError("msg");
+		expect(err).toBeInstanceOf(Error);
+		expect(err.name).toBe("PermissionError");
+		expect(err.status).toBe(403);
+		expect(err.public).toBe(true);
+		expect(err.message).toBe("msg");
+	});
 
-    it('ItemNotFoundError should be configured correctly', () => {
-        const err = new errs.ItemNotFoundError('123');
-        expect(err.name).toBe('ItemNotFoundError');
-        expect(err.status).toBe(404);
-        expect(err.public).toBe(true);
-        expect(err.message).toContain('123');
-    });
+	it("ItemNotFoundError should be configured correctly", () => {
+		const err = new errs.ItemNotFoundError("123");
+		expect(err.name).toBe("ItemNotFoundError");
+		expect(err.status).toBe(404);
+		expect(err.public).toBe(true);
+		expect(err.message).toContain("123");
+	});
 
-    it('AuthError should be configured correctly', () => {
-        const err = new errs.AuthError('msg', 'i18n_key');
-        expect(err.name).toBe('AuthError');
-        expect(err.status).toBe(400);
-        expect(err.public).toBe(true);
-        expect(err.message_i18n).toBe('i18n_key');
-    });
+	it("AuthError should be configured correctly", () => {
+		const err = new errs.AuthError("msg", "i18n_key");
+		expect(err.name).toBe("AuthError");
+		expect(err.status).toBe(400);
+		expect(err.public).toBe(true);
+		expect(err.message_i18n).toBe("i18n_key");
+	});
 
-    it('InternalError should be configured correctly', () => {
-        const err = new errs.InternalError('msg');
-        expect(err.name).toBe('InternalError');
-        expect(err.status).toBe(500);
-        expect(err.public).toBe(false);
-    });
+	it("InternalError should be configured correctly", () => {
+		const err = new errs.InternalError("msg");
+		expect(err.name).toBe("InternalError");
+		expect(err.status).toBe(500);
+		expect(err.public).toBe(false);
+	});
 
-    it('InternalValidationError should be configured correctly', () => {
-        const err = new errs.InternalValidationError('msg');
-        expect(err.name).toBe('InternalValidationError');
-        expect(err.status).toBe(400);
-        expect(err.public).toBe(false);
-    });
+	it("InternalValidationError should be configured correctly", () => {
+		const err = new errs.InternalValidationError("msg");
+		expect(err.name).toBe("InternalValidationError");
+		expect(err.status).toBe(400);
+		expect(err.public).toBe(false);
+	});
 
-    it('ConfigurationError should be configured correctly', () => {
-        const err = new errs.ConfigurationError('msg');
-        expect(err.name).toBe('ConfigurationError');
-        expect(err.status).toBe(400);
-        expect(err.public).toBe(true);
-    });
+	it("ConfigurationError should be configured correctly", () => {
+		const err = new errs.ConfigurationError("msg");
+		expect(err.name).toBe("ConfigurationError");
+		expect(err.status).toBe(400);
+		expect(err.public).toBe(true);
+	});
 
-    it('CacheError should be configured correctly', () => {
-        const err = new errs.CacheError('msg');
-        expect(err.name).toBe('CacheError');
-        expect(err.status).toBe(500);
-        expect(err.public).toBe(false);
-    });
+	it("CacheError should be configured correctly", () => {
+		const err = new errs.CacheError("msg");
+		expect(err.name).toBe("CacheError");
+		expect(err.status).toBe(500);
+		expect(err.public).toBe(false);
+	});
 
-    it('ValidationError should be configured correctly', () => {
-        const err = new errs.ValidationError('msg');
-        expect(err.name).toBe('ValidationError');
-        expect(err.status).toBe(400);
-        expect(err.public).toBe(true);
-    });
+	it("ValidationError should be configured correctly", () => {
+		const err = new errs.ValidationError("msg");
+		expect(err.name).toBe("ValidationError");
+		expect(err.status).toBe(400);
+		expect(err.public).toBe(true);
+	});
 
-    it('AssertionFailedError should be configured correctly', () => {
-        const err = new errs.AssertionFailedError('msg');
-        expect(err.name).toBe('AssertionFailedError');
-        expect(err.status).toBe(400);
-        expect(err.public).toBe(false);
-    });
+	it("AssertionFailedError should be configured correctly", () => {
+		const err = new errs.AssertionFailedError("msg");
+		expect(err.name).toBe("AssertionFailedError");
+		expect(err.status).toBe(400);
+		expect(err.public).toBe(false);
+	});
 
-    it('UnauthorizedError should be configured correctly', () => {
-        const err = new errs.UnauthorizedError('msg');
-        expect(err.name).toBe('UnauthorizedError');
-        expect(err.status).toBe(401);
-        expect(err.public).toBe(true);
-    });
+	it("UnauthorizedError should be configured correctly", () => {
+		const err = new errs.UnauthorizedError("msg");
+		expect(err.name).toBe("UnauthorizedError");
+		expect(err.status).toBe(401);
+		expect(err.public).toBe(true);
+	});
 
-    it('CommandError should be configured correctly', () => {
-        const err = new errs.CommandError('stderr output', 127);
-        expect(err.name).toBe('CommandError');
-        expect(err.message).toBe('stderr output');
-        expect(err.code).toBe(127);
-        expect(err.public).toBe(false);
-    });
+	it("CommandError should be configured correctly", () => {
+		const err = new errs.CommandError("stderr output", 127);
+		expect(err.name).toBe("CommandError");
+		expect(err.message).toBe("stderr output");
+		expect(err.code).toBe(127);
+		expect(err.public).toBe(false);
+	});
 });

--- a/backend/test/lib/service-icons.test.js
+++ b/backend/test/lib/service-icons.test.js
@@ -1,54 +1,54 @@
-import { describe, it, expect } from 'vitest';
-import serviceIcons from '../../lib/service-icons.js';
+import { describe, it, expect } from "vitest";
+import serviceIcons from "../../lib/service-icons.js";
 
-describe('backend/lib/service-icons.js', () => {
-    describe('detectService', () => {
-        it('should detect service by port', () => {
-            const service = serviceIcons.detectService(8123);
-            expect(service.name).toBe('home-assistant');
-        });
+describe("backend/lib/service-icons.js", () => {
+	describe("detectService", () => {
+		it("should detect service by port", () => {
+			const service = serviceIcons.detectService(8123);
+			expect(service.name).toBe("home-assistant");
+		});
 
-        it('should detect service by hostname', () => {
-            const service = serviceIcons.detectService(8080, 'zigbee2mqtt.local');
-            expect(service.name).toBe('zigbee2mqtt');
-        });
+		it("should detect service by hostname", () => {
+			const service = serviceIcons.detectService(8080, "zigbee2mqtt.local");
+			expect(service.name).toBe("zigbee2mqtt");
+		});
 
-        it('should return null for unknown service', () => {
-            const service = serviceIcons.detectService(99999);
-            expect(service).toBeNull();
-        });
+		it("should return null for unknown service", () => {
+			const service = serviceIcons.detectService(99999);
+			expect(service).toBeNull();
+		});
 
-        it('should prefer hostname match over port match', () => {
-            // If I use 8080 and 'qbittorrent', it should match qbittorrent
-            const service = serviceIcons.detectService(8080, 'qbittorrent');
-            expect(service.name).toBe('qbittorrent');
-        });
-    });
+		it("should prefer hostname match over port match", () => {
+			// If I use 8080 and 'qbittorrent', it should match qbittorrent
+			const service = serviceIcons.detectService(8080, "qbittorrent");
+			expect(service.name).toBe("qbittorrent");
+		});
+	});
 
-    describe('getIconUrl', () => {
-        it('should return correct URL', () => {
-            const url = serviceIcons.getIconUrl('test-service');
-            expect(url).toContain('test-service.svg');
-            expect(url).toContain(serviceIcons.ICON_CDN_BASE);
-        });
-    });
+	describe("getIconUrl", () => {
+		it("should return correct URL", () => {
+			const url = serviceIcons.getIconUrl("test-service");
+			expect(url).toContain("test-service.svg");
+			expect(url).toContain(serviceIcons.ICON_CDN_BASE);
+		});
+	});
 
-    describe('getAllServices', () => {
-        it('should return list of unique services', () => {
-            const services = serviceIcons.getAllServices();
-            expect(Array.isArray(services)).toBe(true);
-            expect(services.length).toBeGreaterThan(0);
+	describe("getAllServices", () => {
+		it("should return list of unique services", () => {
+			const services = serviceIcons.getAllServices();
+			expect(Array.isArray(services)).toBe(true);
+			expect(services.length).toBeGreaterThan(0);
 
-            // Check structure
-            const first = services[0];
-            expect(first).toHaveProperty('name');
-            expect(first).toHaveProperty('displayName');
-            expect(first).toHaveProperty('iconUrl');
+			// Check structure
+			const first = services[0];
+			expect(first).toHaveProperty("name");
+			expect(first).toHaveProperty("displayName");
+			expect(first).toHaveProperty("iconUrl");
 
-            // Check uniqueness
-            const names = services.map(s => s.name);
-            const uniqueNames = new Set(names);
-            expect(names.length).toBe(uniqueNames.size);
-        });
-    });
+			// Check uniqueness
+			const names = services.map((s) => s.name);
+			const uniqueNames = new Set(names);
+			expect(names.length).toBe(uniqueNames.size);
+		});
+	});
 });

--- a/backend/test/lib/service-icons.test.js
+++ b/backend/test/lib/service-icons.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import serviceIcons from '../../lib/service-icons.js';
+
+describe('backend/lib/service-icons.js', () => {
+    describe('detectService', () => {
+        it('should detect service by port', () => {
+            const service = serviceIcons.detectService(8123);
+            expect(service.name).toBe('home-assistant');
+        });
+
+        it('should detect service by hostname', () => {
+            const service = serviceIcons.detectService(8080, 'zigbee2mqtt.local');
+            expect(service.name).toBe('zigbee2mqtt');
+        });
+
+        it('should return null for unknown service', () => {
+            const service = serviceIcons.detectService(99999);
+            expect(service).toBeNull();
+        });
+
+        it('should prefer hostname match over port match', () => {
+            // If I use 8080 and 'qbittorrent', it should match qbittorrent
+            const service = serviceIcons.detectService(8080, 'qbittorrent');
+            expect(service.name).toBe('qbittorrent');
+        });
+    });
+
+    describe('getIconUrl', () => {
+        it('should return correct URL', () => {
+            const url = serviceIcons.getIconUrl('test-service');
+            expect(url).toContain('test-service.svg');
+            expect(url).toContain(serviceIcons.ICON_CDN_BASE);
+        });
+    });
+
+    describe('getAllServices', () => {
+        it('should return list of unique services', () => {
+            const services = serviceIcons.getAllServices();
+            expect(Array.isArray(services)).toBe(true);
+            expect(services.length).toBeGreaterThan(0);
+
+            // Check structure
+            const first = services[0];
+            expect(first).toHaveProperty('name');
+            expect(first).toHaveProperty('displayName');
+            expect(first).toHaveProperty('iconUrl');
+
+            // Check uniqueness
+            const names = services.map(s => s.name);
+            const uniqueNames = new Set(names);
+            expect(names.length).toBe(uniqueNames.size);
+        });
+    });
+});

--- a/backend/test/lib/utils.test.js
+++ b/backend/test/lib/utils.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import utils from '../../lib/utils.js';
+import fs from 'node:fs';
+import { execFile as nodeExecFile } from 'node:child_process';
+
+// Mock fs
+vi.mock('node:fs', () => {
+    return {
+        default: {
+            promises: {
+                readdir: vi.fn(),
+                readFile: vi.fn(),
+                writeFile: vi.fn(),
+                mkdir: vi.fn(),
+            },
+            existsSync: vi.fn(),
+        }
+    };
+});
+
+// Mock child_process
+vi.mock('node:child_process', () => ({
+    execFile: vi.fn(),
+}));
+
+// Mock logger
+vi.mock('../../logger.js', () => ({
+    global: {},
+    debug: vi.fn(),
+}));
+
+describe('backend/lib/utils.js', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('writeHash', () => {
+        it('should calculate hash from templates and write to file', async () => {
+            // Mock fs.promises.readdir to return some files
+            fs.promises.readdir.mockResolvedValue(['template1.conf', 'template2.conf']);
+
+            // Mock fs.promises.readFile to return content with env vars
+            fs.promises.readFile.mockImplementation((path) => {
+                if (path.includes('template1.conf')) return Promise.resolve('server_name {{ env.DOMAIN }};');
+                if (path.includes('template2.conf')) return Promise.resolve('listen {{ env.PORT }};');
+                return Promise.resolve('');
+            });
+
+            // Mock process.env
+            const originalEnv = process.env;
+            process.env = { ...originalEnv, DOMAIN: 'example.com', PORT: '80', TV: '1' };
+
+            // Mock mkdir to succeed
+            fs.promises.mkdir.mockResolvedValue();
+
+            await utils.writeHash();
+
+            // Verify readdir was called
+            expect(fs.promises.readdir).toHaveBeenCalled();
+
+            // Verify readFile was called for each file
+            expect(fs.promises.readFile).toHaveBeenCalledTimes(2);
+
+            // Verify writeFile was called with a hash
+            expect(fs.promises.writeFile).toHaveBeenCalledWith(
+                '/data/shieldpm/env.sha512sum',
+                expect.any(String)
+            );
+
+            // Restore process.env
+            process.env = originalEnv;
+        });
+
+        it('should create directory if it does not exist', async () => {
+             fs.promises.readdir.mockResolvedValue([]);
+             fs.existsSync.mockReturnValue(false);
+             fs.promises.mkdir.mockResolvedValue();
+
+             await utils.writeHash();
+
+             expect(fs.promises.mkdir).toHaveBeenCalledWith('/data/shieldpm', { recursive: true });
+        });
+    });
+
+    describe('execFile', () => {
+        it('should execute a command and return stdout + stderr', async () => {
+            // Mock nodeExecFile to call the callback with success
+            nodeExecFile.mockImplementation((cmd, args, callback) => {
+                // Handle optional args
+                if (typeof args === 'function') {
+                    callback = args;
+                    args = [];
+                }
+                callback(null, { stdout: 'output', stderr: 'error' });
+            });
+
+            const result = await utils.execFile('ls', ['-la']);
+            expect(result).toBe('outputerror');
+            expect(nodeExecFile).toHaveBeenCalledWith('ls', ['-la'], expect.any(Function));
+        });
+
+        it('should throw CommandError on failure', async () => {
+            // Mock nodeExecFile to call the callback with error
+            nodeExecFile.mockImplementation((cmd, args, callback) => {
+                 if (typeof args === 'function') {
+                    callback = args;
+                    args = [];
+                }
+                const err = new Error('Command failed');
+                err.stdout = 'stdout info';
+                err.stderr = 'stderr info';
+                callback(err);
+            });
+
+            await expect(utils.execFile('fail', [])).rejects.toThrow('stdout infostderr info');
+        });
+    });
+
+    describe('omitRow', () => {
+        it('should omit specified keys from an object', () => {
+            const row = { a: 1, b: 2, c: 3 };
+            const omit = utils.omitRow(['b']);
+            const result = omit(row);
+            expect(result).toEqual({ a: 1, c: 3 });
+        });
+    });
+
+    describe('omitRows', () => {
+        it('should omit specified keys from an array of objects', () => {
+            const rows = [{ a: 1, b: 2 }, { a: 3, b: 4 }];
+            const omit = utils.omitRows(['b']);
+            const result = omit(rows);
+            expect(result).toEqual([{ a: 1 }, { a: 3 }]);
+        });
+    });
+
+    describe('getRenderEngine', () => {
+        it('should return a Liquid engine instance', () => {
+            const engine = utils.getRenderEngine();
+            expect(engine).toBeDefined();
+            expect(engine.renderFile).toBeDefined();
+        });
+
+        it('should register nginxAccessRule filter', async () => {
+             const engine = utils.getRenderEngine();
+             const template = `{{ rule | nginxAccessRule }}`;
+             const context = { rule: { directive: 'allow', address: '127.0.0.1' } };
+             const result = await engine.parseAndRender(template, context);
+             expect(result).toBe('allow 127.0.0.1;');
+        });
+
+        it('should return empty string for invalid nginxAccessRule input', async () => {
+             const engine = utils.getRenderEngine();
+             const template = `{{ rule | nginxAccessRule }}`;
+             const context = { rule: {} }; // Missing properties
+             const result = await engine.parseAndRender(template, context);
+             expect(result).toBe('');
+        });
+    });
+});

--- a/backend/test/lib/utils.test.js
+++ b/backend/test/lib/utils.test.js
@@ -1,160 +1,160 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import utils from '../../lib/utils.js';
-import fs from 'node:fs';
-import { execFile as nodeExecFile } from 'node:child_process';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import utils from "../../lib/utils.js";
+import fs from "node:fs";
+import { execFile as nodeExecFile } from "node:child_process";
 
 // Mock fs
-vi.mock('node:fs', () => {
-    return {
-        default: {
-            promises: {
-                readdir: vi.fn(),
-                readFile: vi.fn(),
-                writeFile: vi.fn(),
-                mkdir: vi.fn(),
-            },
-            existsSync: vi.fn(),
-        }
-    };
+vi.mock("node:fs", () => {
+	return {
+		default: {
+			promises: {
+				readdir: vi.fn(),
+				readFile: vi.fn(),
+				writeFile: vi.fn(),
+				mkdir: vi.fn(),
+			},
+			existsSync: vi.fn(),
+		},
+	};
 });
 
 // Mock child_process
-vi.mock('node:child_process', () => ({
-    execFile: vi.fn(),
+vi.mock("node:child_process", () => ({
+	execFile: vi.fn(),
 }));
 
 // Mock logger
-vi.mock('../../logger.js', () => ({
-    global: {},
-    debug: vi.fn(),
+vi.mock("../../logger.js", () => ({
+	global: {},
+	debug: vi.fn(),
 }));
 
-describe('backend/lib/utils.js', () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+describe("backend/lib/utils.js", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
-    describe('writeHash', () => {
-        it('should calculate hash from templates and write to file', async () => {
-            // Mock fs.promises.readdir to return some files
-            fs.promises.readdir.mockResolvedValue(['template1.conf', 'template2.conf']);
+	describe("writeHash", () => {
+		it("should calculate hash from templates and write to file", async () => {
+			// Mock fs.promises.readdir to return some files
+			fs.promises.readdir.mockResolvedValue(["template1.conf", "template2.conf"]);
 
-            // Mock fs.promises.readFile to return content with env vars
-            fs.promises.readFile.mockImplementation((path) => {
-                if (path.includes('template1.conf')) return Promise.resolve('server_name {{ env.DOMAIN }};');
-                if (path.includes('template2.conf')) return Promise.resolve('listen {{ env.PORT }};');
-                return Promise.resolve('');
-            });
+			// Mock fs.promises.readFile to return content with env vars
+			fs.promises.readFile.mockImplementation((path) => {
+				if (path.includes("template1.conf")) return Promise.resolve("server_name {{ env.DOMAIN }};");
+				if (path.includes("template2.conf")) return Promise.resolve("listen {{ env.PORT }};");
+				return Promise.resolve("");
+			});
 
-            // Mock process.env
-            const originalEnv = process.env;
-            process.env = { ...originalEnv, DOMAIN: 'example.com', PORT: '80', TV: '1' };
+			// Mock process.env
+			const originalEnv = process.env;
+			process.env = { ...originalEnv, DOMAIN: "example.com", PORT: "80", TV: "1" };
 
-            // Mock mkdir to succeed
-            fs.promises.mkdir.mockResolvedValue();
+			// Mock mkdir to succeed
+			fs.promises.mkdir.mockResolvedValue();
 
-            await utils.writeHash();
+			await utils.writeHash();
 
-            // Verify readdir was called
-            expect(fs.promises.readdir).toHaveBeenCalled();
+			// Verify readdir was called
+			expect(fs.promises.readdir).toHaveBeenCalled();
 
-            // Verify readFile was called for each file
-            expect(fs.promises.readFile).toHaveBeenCalledTimes(2);
+			// Verify readFile was called for each file
+			expect(fs.promises.readFile).toHaveBeenCalledTimes(2);
 
-            // Verify writeFile was called with a hash
-            expect(fs.promises.writeFile).toHaveBeenCalledWith(
-                '/data/shieldpm/env.sha512sum',
-                expect.any(String)
-            );
+			// Verify writeFile was called with a hash
+			expect(fs.promises.writeFile).toHaveBeenCalledWith("/data/shieldpm/env.sha512sum", expect.any(String));
 
-            // Restore process.env
-            process.env = originalEnv;
-        });
+			// Restore process.env
+			process.env = originalEnv;
+		});
 
-        it('should create directory if it does not exist', async () => {
-             fs.promises.readdir.mockResolvedValue([]);
-             fs.existsSync.mockReturnValue(false);
-             fs.promises.mkdir.mockResolvedValue();
+		it("should create directory if it does not exist", async () => {
+			fs.promises.readdir.mockResolvedValue([]);
+			fs.existsSync.mockReturnValue(false);
+			fs.promises.mkdir.mockResolvedValue();
 
-             await utils.writeHash();
+			await utils.writeHash();
 
-             expect(fs.promises.mkdir).toHaveBeenCalledWith('/data/shieldpm', { recursive: true });
-        });
-    });
+			expect(fs.promises.mkdir).toHaveBeenCalledWith("/data/shieldpm", { recursive: true });
+		});
+	});
 
-    describe('execFile', () => {
-        it('should execute a command and return stdout + stderr', async () => {
-            // Mock nodeExecFile to call the callback with success
-            nodeExecFile.mockImplementation((_cmd, args, callback) => {
-                // Handle optional args
-                let cb = callback;
-                if (typeof args === 'function') {
-                    cb = args;
-                }
-                cb(null, { stdout: 'output', stderr: 'error' });
-            });
+	describe("execFile", () => {
+		it("should execute a command and return stdout + stderr", async () => {
+			// Mock nodeExecFile to call the callback with success
+			nodeExecFile.mockImplementation((_cmd, args, callback) => {
+				// Handle optional args
+				let cb = callback;
+				if (typeof args === "function") {
+					cb = args;
+				}
+				cb(null, { stdout: "output", stderr: "error" });
+			});
 
-            const result = await utils.execFile('ls', ['-la']);
-            expect(result).toBe('outputerror');
-            expect(nodeExecFile).toHaveBeenCalledWith('ls', ['-la'], expect.any(Function));
-        });
+			const result = await utils.execFile("ls", ["-la"]);
+			expect(result).toBe("outputerror");
+			expect(nodeExecFile).toHaveBeenCalledWith("ls", ["-la"], expect.any(Function));
+		});
 
-        it('should throw CommandError on failure', async () => {
-            // Mock nodeExecFile to call the callback with error
-            nodeExecFile.mockImplementation((_cmd, args, callback) => {
-                 let cb = callback;
-                 if (typeof args === 'function') {
-                    cb = args;
-                }
-                const err = new Error('Command failed');
-                err.stdout = 'stdout info';
-                err.stderr = 'stderr info';
-                cb(err);
-            });
+		it("should throw CommandError on failure", async () => {
+			// Mock nodeExecFile to call the callback with error
+			nodeExecFile.mockImplementation((_cmd, args, callback) => {
+				let cb = callback;
+				if (typeof args === "function") {
+					cb = args;
+				}
+				const err = new Error("Command failed");
+				err.stdout = "stdout info";
+				err.stderr = "stderr info";
+				cb(err);
+			});
 
-            await expect(utils.execFile('fail', [])).rejects.toThrow('stdout infostderr info');
-        });
-    });
+			await expect(utils.execFile("fail", [])).rejects.toThrow("stdout infostderr info");
+		});
+	});
 
-    describe('omitRow', () => {
-        it('should omit specified keys from an object', () => {
-            const row = { a: 1, b: 2, c: 3 };
-            const omit = utils.omitRow(['b']);
-            const result = omit(row);
-            expect(result).toEqual({ a: 1, c: 3 });
-        });
-    });
+	describe("omitRow", () => {
+		it("should omit specified keys from an object", () => {
+			const row = { a: 1, b: 2, c: 3 };
+			const omit = utils.omitRow(["b"]);
+			const result = omit(row);
+			expect(result).toEqual({ a: 1, c: 3 });
+		});
+	});
 
-    describe('omitRows', () => {
-        it('should omit specified keys from an array of objects', () => {
-            const rows = [{ a: 1, b: 2 }, { a: 3, b: 4 }];
-            const omit = utils.omitRows(['b']);
-            const result = omit(rows);
-            expect(result).toEqual([{ a: 1 }, { a: 3 }]);
-        });
-    });
+	describe("omitRows", () => {
+		it("should omit specified keys from an array of objects", () => {
+			const rows = [
+				{ a: 1, b: 2 },
+				{ a: 3, b: 4 },
+			];
+			const omit = utils.omitRows(["b"]);
+			const result = omit(rows);
+			expect(result).toEqual([{ a: 1 }, { a: 3 }]);
+		});
+	});
 
-    describe('getRenderEngine', () => {
-        it('should return a Liquid engine instance', () => {
-            const engine = utils.getRenderEngine();
-            expect(engine).toBeDefined();
-            expect(engine.renderFile).toBeDefined();
-        });
+	describe("getRenderEngine", () => {
+		it("should return a Liquid engine instance", () => {
+			const engine = utils.getRenderEngine();
+			expect(engine).toBeDefined();
+			expect(engine.renderFile).toBeDefined();
+		});
 
-        it('should register nginxAccessRule filter', async () => {
-             const engine = utils.getRenderEngine();
-             const template = `{{ rule | nginxAccessRule }}`;
-             const context = { rule: { directive: 'allow', address: '127.0.0.1' } };
-             const result = await engine.parseAndRender(template, context);
-             expect(result).toBe('allow 127.0.0.1;');
-        });
+		it("should register nginxAccessRule filter", async () => {
+			const engine = utils.getRenderEngine();
+			const template = "{{ rule | nginxAccessRule }}";
+			const context = { rule: { directive: "allow", address: "127.0.0.1" } };
+			const result = await engine.parseAndRender(template, context);
+			expect(result).toBe("allow 127.0.0.1;");
+		});
 
-        it('should return empty string for invalid nginxAccessRule input', async () => {
-             const engine = utils.getRenderEngine();
-             const template = `{{ rule | nginxAccessRule }}`;
-             const context = { rule: {} }; // Missing properties
-             const result = await engine.parseAndRender(template, context);
-             expect(result).toBe('');
-        });
-    });
+		it("should return empty string for invalid nginxAccessRule input", async () => {
+			const engine = utils.getRenderEngine();
+			const template = "{{ rule | nginxAccessRule }}";
+			const context = { rule: {} }; // Missing properties
+			const result = await engine.parseAndRender(template, context);
+			expect(result).toBe("");
+		});
+	});
 });

--- a/backend/test/lib/utils.test.js
+++ b/backend/test/lib/utils.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import utils from '../../lib/utils.js';
 import fs from 'node:fs';
 import { execFile as nodeExecFile } from 'node:child_process';
@@ -85,13 +85,13 @@ describe('backend/lib/utils.js', () => {
     describe('execFile', () => {
         it('should execute a command and return stdout + stderr', async () => {
             // Mock nodeExecFile to call the callback with success
-            nodeExecFile.mockImplementation((cmd, args, callback) => {
+            nodeExecFile.mockImplementation((_cmd, args, callback) => {
                 // Handle optional args
+                let cb = callback;
                 if (typeof args === 'function') {
-                    callback = args;
-                    args = [];
+                    cb = args;
                 }
-                callback(null, { stdout: 'output', stderr: 'error' });
+                cb(null, { stdout: 'output', stderr: 'error' });
             });
 
             const result = await utils.execFile('ls', ['-la']);
@@ -101,15 +101,15 @@ describe('backend/lib/utils.js', () => {
 
         it('should throw CommandError on failure', async () => {
             // Mock nodeExecFile to call the callback with error
-            nodeExecFile.mockImplementation((cmd, args, callback) => {
+            nodeExecFile.mockImplementation((_cmd, args, callback) => {
+                 let cb = callback;
                  if (typeof args === 'function') {
-                    callback = args;
-                    args = [];
+                    cb = args;
                 }
                 const err = new Error('Command failed');
                 err.stdout = 'stdout info';
                 err.stderr = 'stderr info';
-                callback(err);
+                cb(err);
             });
 
             await expect(utils.execFile('fail', [])).rejects.toThrow('stdout infostderr info');

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@apidevtools/json-schema-ref-parser@^15.2.2":
+  version "15.2.2"
+  resolved "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.2.2.tgz"
+  integrity sha512-54fvjSwWiBTdVviiUItOCeyxtPSBmCrSEjlOl8XFEDuYD3lXY1lOBWKim/WJ3i1EYzdGx6rSOjK5KRDMppLI4Q==
+  dependencies:
+    js-yaml "^4.1.1"
+
 "@apidevtools/json-schema-ref-parser@14.0.1":
   version "14.0.1"
   resolved "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz"
@@ -9,13 +16,6 @@
   dependencies:
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
-
-"@apidevtools/json-schema-ref-parser@^15.2.2":
-  version "15.2.2"
-  resolved "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.2.2.tgz"
-  integrity sha512-54fvjSwWiBTdVviiUItOCeyxtPSBmCrSEjlOl8XFEDuYD3lXY1lOBWKim/WJ3i1EYzdGx6rSOjK5KRDMppLI4Q==
-  dependencies:
-    js-yaml "^4.1.1"
 
 "@apidevtools/openapi-schemas@^2.1.0":
   version "2.1.0"
@@ -46,7 +46,7 @@
 
 "@biomejs/biome@^2.4.4":
   version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/biome/-/biome-2.4.4.tgz#009d1751d061946b320e663e5894af60310f355a"
+  resolved "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.4.tgz"
   integrity sha512-tigwWS5KfJf0cABVd52NVaXyAVv4qpUXOWJ1rxFL8xF1RVoeS2q/LK+FHgYoKMclJCuRoCWAPy1IXaN9/mS61Q==
   optionalDependencies:
     "@biomejs/cli-darwin-arm64" "2.4.4"
@@ -58,175 +58,15 @@
     "@biomejs/cli-win32-arm64" "2.4.4"
     "@biomejs/cli-win32-x64" "2.4.4"
 
-"@biomejs/cli-darwin-arm64@2.4.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.4.tgz#a8af5254fcc9dda28a1da26125427df083a13579"
-  integrity sha512-jZ+Xc6qvD6tTH5jM6eKX44dcbyNqJHssfl2nnwT6vma6B1sj7ZLTGIk6N5QwVBs5xGN52r3trk5fgd3sQ9We9A==
-
-"@biomejs/cli-darwin-x64@2.4.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.4.tgz#6de17d5bb3afaf3275bc602fb7e61fefe31dab84"
-  integrity sha512-Dh1a/+W+SUCXhEdL7TiX3ArPTFCQKJTI1mGncZNWfO+6suk+gYA4lNyJcBB+pwvF49uw0pEbUS49BgYOY4hzUg==
-
-"@biomejs/cli-linux-arm64-musl@2.4.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.4.tgz#4c55afe87d555782f46e729212acd4e0411b1703"
-  integrity sha512-+sPAXq3bxmFwhVFJnSwkSF5Rw2ZAJMH3MF6C9IveAEOdSpgajPhoQhbbAK12SehN9j2QrHpk4J/cHsa/HqWaYQ==
-
-"@biomejs/cli-linux-arm64@2.4.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.4.tgz#2c8848461bd5195d3e887b0c9fc9c1b441c727ec"
-  integrity sha512-V/NFfbWhsUU6w+m5WYbBenlEAz8eYnSqRMDMAW3K+3v0tYVkNyZn8VU0XPxk/lOqNXLSCCrV7FmV/u3SjCBShg==
-
-"@biomejs/cli-linux-x64-musl@2.4.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.4.tgz#f40336d8c1534887c7ef4198b2b4772aca702ee8"
-  integrity sha512-gGvFTGpOIQDb5CQ2VC0n9Z2UEqlP46c4aNgHmAMytYieTGEcfqhfCFnhs6xjt0S3igE6q5GLuIXtdQt3Izok+g==
-
 "@biomejs/cli-linux-x64@2.4.4":
   version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.4.tgz#397cadb0ec1e76a993d21ee424bcf2cf7976243e"
+  resolved "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.4.tgz"
   integrity sha512-R4+ZCDtG9kHArasyBO+UBD6jr/FcFCTH8QkNTOCu0pRJzCWyWC4EtZa2AmUZB5h3e0jD7bRV2KvrENcf8rndBg==
-
-"@biomejs/cli-win32-arm64@2.4.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.4.tgz#7d767c15ce20ee39bc1430c2057ccd0208cf12fe"
-  integrity sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q==
-
-"@biomejs/cli-win32-x64@2.4.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.4.tgz#998e87083ff9657a24b4b2f6afcb803a2e820000"
-  integrity sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A==
-
-"@esbuild/aix-ppc64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz#815b39267f9bffd3407ea6c376ac32946e24f8d2"
-  integrity sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==
-
-"@esbuild/android-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz#19b882408829ad8e12b10aff2840711b2da361e8"
-  integrity sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==
-
-"@esbuild/android-arm@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.3.tgz#90be58de27915efa27b767fcbdb37a4470627d7b"
-  integrity sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==
-
-"@esbuild/android-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.3.tgz#d7dcc976f16e01a9aaa2f9b938fbec7389f895ac"
-  integrity sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==
-
-"@esbuild/darwin-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz#9f6cac72b3a8532298a6a4493ed639a8988e8abd"
-  integrity sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==
-
-"@esbuild/darwin-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz#ac61d645faa37fd650340f1866b0812e1fb14d6a"
-  integrity sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==
-
-"@esbuild/freebsd-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz#b8625689d73cf1830fe58c39051acdc12474ea1b"
-  integrity sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==
-
-"@esbuild/freebsd-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz#07be7dd3c9d42fe0eccd2ab9f9ded780bc53bead"
-  integrity sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==
-
-"@esbuild/linux-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz#bf31918fe5c798586460d2b3d6c46ed2c01ca0b6"
-  integrity sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==
-
-"@esbuild/linux-arm@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz#28493ee46abec1dc3f500223cd9f8d2df08f9d11"
-  integrity sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==
-
-"@esbuild/linux-ia32@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz#750752a8b30b43647402561eea764d0a41d0ee29"
-  integrity sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==
-
-"@esbuild/linux-loong64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz#a5a92813a04e71198c50f05adfaf18fc1e95b9ed"
-  integrity sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==
-
-"@esbuild/linux-mips64el@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz#deb45d7fd2d2161eadf1fbc593637ed766d50bb1"
-  integrity sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==
-
-"@esbuild/linux-ppc64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz#6f39ae0b8c4d3d2d61a65b26df79f6e12a1c3d78"
-  integrity sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==
-
-"@esbuild/linux-riscv64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz#4c5c19c3916612ec8e3915187030b9df0b955c1d"
-  integrity sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==
-
-"@esbuild/linux-s390x@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz#9ed17b3198fa08ad5ccaa9e74f6c0aff7ad0156d"
-  integrity sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==
 
 "@esbuild/linux-x64@0.27.3":
   version "0.27.3"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz"
   integrity sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==
-
-"@esbuild/netbsd-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz#dd0cb2fa543205fcd931df44f4786bfcce6df7d7"
-  integrity sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==
-
-"@esbuild/netbsd-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz#028ad1807a8e03e155153b2d025b506c3787354b"
-  integrity sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==
-
-"@esbuild/openbsd-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz#e3c16ff3490c9b59b969fffca87f350ffc0e2af5"
-  integrity sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==
-
-"@esbuild/openbsd-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz#c5a4693fcb03d1cbecbf8b422422468dfc0d2a8b"
-  integrity sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==
-
-"@esbuild/openharmony-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz#082082444f12db564a0775a41e1991c0e125055e"
-  integrity sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==
-
-"@esbuild/sunos-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz#5ab036c53f929e8405c4e96e865a424160a1b537"
-  integrity sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==
-
-"@esbuild/win32-arm64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz#38de700ef4b960a0045370c171794526e589862e"
-  integrity sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==
-
-"@esbuild/win32-ia32@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz#451b93dc03ec5d4f38619e6cd64d9f9eff06f55c"
-  integrity sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==
-
-"@esbuild/win32-x64@0.27.3":
-  version "0.27.3"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz#0eaf705c941a218a43dba8e09f1df1d6cd2f1f17"
-  integrity sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==
 
 "@google/generative-ai@^0.24.1":
   version "0.24.1"
@@ -324,130 +164,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@rollup/rollup-android-arm-eabi@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz#add5e608d4e7be55bc3ca3d962490b8b1890e088"
-  integrity sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==
-
-"@rollup/rollup-android-arm64@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz#10bd0382b73592beee6e9800a69401a29da625c4"
-  integrity sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==
-
-"@rollup/rollup-darwin-arm64@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz#1e99ab04c0b8c619dd7bbde725ba2b87b55bfd81"
-  integrity sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==
-
-"@rollup/rollup-darwin-x64@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz#69e741aeb2839d2e8f0da2ce7a33d8bd23632423"
-  integrity sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==
-
-"@rollup/rollup-freebsd-arm64@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz#3736c232a999c7bef7131355d83ebdf9651a0839"
-  integrity sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==
-
-"@rollup/rollup-freebsd-x64@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz#227dcb8f466684070169942bd3998901c9bfc065"
-  integrity sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==
-
-"@rollup/rollup-linux-arm-gnueabihf@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz#ba004b30df31b724f99ce66e7128248bea17cb0c"
-  integrity sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==
-
-"@rollup/rollup-linux-arm-musleabihf@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz#6929f3e07be6b6da5991f63c6b68b3e473d0a65a"
-  integrity sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==
-
-"@rollup/rollup-linux-arm64-gnu@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz#06e89fd4a25d21fe5575d60b6f913c0e65297bfa"
-  integrity sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==
-
-"@rollup/rollup-linux-arm64-musl@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz#fddabf395b90990d5194038e6cd8c00156ed8ac0"
-  integrity sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==
-
-"@rollup/rollup-linux-loong64-gnu@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz#04c10bb764bbf09a3c1bd90432e92f58d6603c36"
-  integrity sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==
-
-"@rollup/rollup-linux-loong64-musl@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz#f2450361790de80581d8687ea19142d8a4de5c0f"
-  integrity sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==
-
-"@rollup/rollup-linux-ppc64-gnu@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz#0474f4667259e407eee1a6d38e29041b708f6a30"
-  integrity sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==
-
-"@rollup/rollup-linux-ppc64-musl@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz#9f32074819eeb1ddbe51f50ea9dcd61a6745ec33"
-  integrity sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==
-
-"@rollup/rollup-linux-riscv64-gnu@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz#3fdb9d4b1e29fb6b6a6da9f15654d42eb77b99b2"
-  integrity sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==
-
-"@rollup/rollup-linux-riscv64-musl@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz#1de780d64e6be0e3e8762035c22e0d8ea68df8ed"
-  integrity sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==
-
-"@rollup/rollup-linux-s390x-gnu@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz#1da022ffd2d9e9f0fd8344ea49e113001fbcac64"
-  integrity sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==
-
 "@rollup/rollup-linux-x64-gnu@4.57.1":
   version "4.57.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz"
   integrity sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==
-
-"@rollup/rollup-linux-x64-musl@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz"
-  integrity sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==
-
-"@rollup/rollup-openbsd-x64@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz#c51d48c07cd6c466560e5bed934aec688ce02614"
-  integrity sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==
-
-"@rollup/rollup-openharmony-arm64@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz#f09921d0b2a0b60afbf3586d2a7a7f208ba6df17"
-  integrity sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==
-
-"@rollup/rollup-win32-arm64-msvc@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz#08d491717135376e4a99529821c94ecd433d5b36"
-  integrity sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==
-
-"@rollup/rollup-win32-ia32-msvc@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz#b0c12aac1104a8b8f26a5e0098e5facbb3e3964a"
-  integrity sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==
-
-"@rollup/rollup-win32-x64-gnu@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz#b9cccef26f5e6fdc013bf3c0911a3c77428509d0"
-  integrity sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==
-
-"@rollup/rollup-win32-x64-msvc@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz#a03348e7b559c792b6277cc58874b89ef46e1e72"
-  integrity sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==
 
 "@standard-schema/spec@^1.0.0":
   version "1.1.0"
@@ -477,7 +197,7 @@
   resolved "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
-"@types/estree@1.0.8", "@types/estree@^1.0.0":
+"@types/estree@^1.0.0", "@types/estree@1.0.8":
   version "1.0.8"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
@@ -487,7 +207,7 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/node@>=13.7.0":
+"@types/node@^20.0.0 || ^22.0.0 || >=24.0.0", "@types/node@^20.19.0 || >=22.12.0", "@types/node@>=13.7.0":
   version "25.3.0"
   resolved "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz"
   integrity sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==
@@ -584,9 +304,9 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
-ajv@^8.0.0, ajv@^8.17.1, ajv@^8.18.0:
+ajv@^8.0.0, ajv@^8.17.1, ajv@^8.18.0, ajv@^8.5.0:
   version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
   dependencies:
     fast-deep-equal "^3.1.3"
@@ -628,7 +348,7 @@ archiver-utils@^5.0.0, archiver-utils@^5.0.2:
 
 archiver@^7.0.1:
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/archiver/-/archiver-7.0.1.tgz#c9d91c350362040b8927379c7aa69c0655122f61"
+  resolved "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz"
   integrity sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==
   dependencies:
     archiver-utils "^5.0.2"
@@ -692,7 +412,7 @@ b4a@^1.6.4:
 
 balanced-match@^4.0.2:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.3.tgz#6337a2f23e0604a30481423432f99eac603599f9"
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz"
   integrity sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==
 
 bare-events@^2.7.0:
@@ -768,7 +488,7 @@ body-parser@^2.2.1:
 
 brace-expansion@^5.0.2:
   version "5.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.2.tgz#b6c16d0791087af6c2bc463f52a8142046c06b6f"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz"
   integrity sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==
   dependencies:
     balanced-match "^4.0.2"
@@ -912,15 +632,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
-
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 colorette@2.0.19:
   version "2.0.19"
@@ -961,17 +681,17 @@ cookie-parser@^1.4.7:
     cookie "0.7.2"
     cookie-signature "1.0.6"
 
-cookie-signature@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
-  integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
-
 cookie-signature@^1.2.1:
   version "1.2.2"
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz"
   integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
 
-cookie@0.7.2, cookie@^0.7.1:
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+  integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
+
+cookie@^0.7.1, cookie@0.7.2:
   version "0.7.2"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
@@ -1024,7 +744,7 @@ db-errors@^0.2.3:
   resolved "https://registry.npmjs.org/db-errors/-/db-errors-0.2.3.tgz"
   integrity sha512-OOgqgDuCavHXjYSJoV2yGhv6SeG8nk42aoCSoyXLZUH7VwFG27rxbavU1z+VrZbZjphw5UkDQwUlD21MwZpUng==
 
-debug@4, debug@^4.1.1, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3:
+debug@^4.1.1, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3, debug@4:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -1309,7 +1029,7 @@ express-rate-limit@8.2.1:
   dependencies:
     ip-address "10.0.1"
 
-express@5.2.1:
+"express@>= 4.11", express@5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/express/-/express-5.2.1.tgz"
   integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
@@ -1416,11 +1136,6 @@ fs-constants@^1.0.0:
   resolved "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fsevents@~2.3.2, fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -1486,9 +1201,9 @@ github-from-package@0.0.0:
   resolved "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz"
   integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
-glob@^10.0.0, glob@^13.0.6:
+glob@^13.0.6:
   version "13.0.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.6.tgz#078666566a425147ccacfbd2e332deb66a2be71d"
+  resolved "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz"
   integrity sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==
   dependencies:
     minimatch "^10.2.2"
@@ -1585,15 +1300,15 @@ ignore@^5.1.4:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-inherits@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-  integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
-
 inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+  integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
 
 ini@~1.3.0:
   version "1.3.8"
@@ -1605,25 +1320,20 @@ interpret@^2.2.0:
   resolved "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-ip-address@10.0.1:
+ip-address@^10.0.1, ip-address@10.0.1:
   version "10.0.1"
   resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz"
   integrity sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==
-
-ip-address@^10.0.1:
-  version "10.1.0"
-  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz"
-  integrity sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==
-
-ipaddr.js@1.9.1:
-  version "1.9.1"
-  resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
-  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 ipaddr.js@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz"
   integrity sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -1756,7 +1466,7 @@ jws@^4.0.1:
     jwa "^2.0.1"
     safe-buffer "^5.0.1"
 
-knex@3.1.0:
+knex@>=1.0.1, knex@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/knex/-/knex-3.1.0.tgz"
   integrity sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==
@@ -1860,7 +1570,7 @@ long@^5.0.0, long@^5.3.2:
 
 lru-cache@^11.0.0:
   version "11.2.6"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.2.6.tgz#356bf8a29e88a7a2945507b31f6429a65a192c58"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz"
   integrity sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==
 
 lru-cache@^7.14.1:
@@ -1912,9 +1622,9 @@ mimic-response@^3.1.0:
   resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
-minimatch@^10.2.1, minimatch@^10.2.2, minimatch@^5.1.0:
+minimatch@^10.2.1:
   version "10.2.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.2.tgz#361603ee323cfb83496fea2ae17cc44ea4e1f99f"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz"
   integrity sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==
   dependencies:
     brace-expansion "^5.0.2"
@@ -1946,19 +1656,19 @@ mri@^1.2.0:
   resolved "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
-ms@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
 mysql2@^3.17.4:
   version "3.17.4"
-  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-3.17.4.tgz#c88ff408019eda32431136da52556d9df3c25542"
+  resolved "https://registry.npmjs.org/mysql2/-/mysql2-3.17.4.tgz"
   integrity sha512-RnfuK5tyIuaiPMWOCTTl4vQX/mQXqSA8eoIbwvWccadvPGvh+BYWWVecInMS5s7wcLUkze8LqJzwB/+A4uwuAA==
   dependencies:
     aws-ssl-profiles "^1.1.2"
@@ -2059,9 +1769,9 @@ once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-openapi-types@^12.1.3:
+openapi-types@^12.1.3, openapi-types@>=7:
   version "12.1.3"
-  resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-12.1.3.tgz#471995eb26c4b97b7bd356aacf7b91b73e777dd3"
+  resolved "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz"
   integrity sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==
 
 openid-client@^6.8.2:
@@ -2148,7 +1858,7 @@ path-parse@^1.0.7:
 
 path-scurry@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.2.tgz#6be0d0ee02a10d9e0de7a98bae65e182c9061f85"
+  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz"
   integrity sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==
   dependencies:
     lru-cache "^11.0.0"
@@ -2177,15 +1887,15 @@ pg-cloudflare@^1.3.0:
   resolved "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz"
   integrity sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==
 
-pg-connection-string@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz"
-  integrity sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==
-
 pg-connection-string@^2.11.0:
   version "2.11.0"
   resolved "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz"
   integrity sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==
+
+pg-connection-string@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz"
+  integrity sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==
 
 pg-int8@1.0.1:
   version "1.0.1"
@@ -2213,7 +1923,7 @@ pg-types@2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.17.2:
+pg@^8.17.2, pg@>=8.0:
   version "8.18.0"
   resolved "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz"
   integrity sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==
@@ -2238,7 +1948,7 @@ picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^4.0.3:
+"picomatch@^3 || ^4", picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
@@ -2383,9 +2093,9 @@ punycode.js@2.3.1:
   resolved "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz"
   integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
-qs@>=6.14.2, qs@^6.14.0, qs@^6.14.1:
+qs@>=6.14.2:
   version "6.15.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.0.tgz#db8fd5d1b1d2d6b5b33adaf87429805f1909e7b3"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz"
   integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
   dependencies:
     side-channel "^1.1.0"
@@ -2428,7 +2138,25 @@ readable-stream@^2.0.5:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0:
+readable-stream@^3.1.1:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-stream@^3.4.0:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-stream@^3.5.0:
   version "3.6.2"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -2771,15 +2499,6 @@ streamx@^2.15.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
 string_decoder@^1.1.1, string_decoder@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
@@ -2793,6 +2512,15 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -3022,7 +2750,7 @@ vary@^1.1.2:
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-"vite@^6.0.0 || ^7.0.0":
+"vite@^6.0.0 || ^7.0.0", "vite@^6.0.0 || ^7.0.0-0":
   version "7.3.1"
   resolved "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz"
   integrity sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@apidevtools/json-schema-ref-parser@^15.2.2":
-  version "15.2.2"
-  resolved "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.2.2.tgz"
-  integrity sha512-54fvjSwWiBTdVviiUItOCeyxtPSBmCrSEjlOl8XFEDuYD3lXY1lOBWKim/WJ3i1EYzdGx6rSOjK5KRDMppLI4Q==
-  dependencies:
-    js-yaml "^4.1.1"
-
 "@apidevtools/json-schema-ref-parser@14.0.1":
   version "14.0.1"
   resolved "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz"
@@ -16,6 +9,13 @@
   dependencies:
     "@types/json-schema" "^7.0.15"
     js-yaml "^4.1.0"
+
+"@apidevtools/json-schema-ref-parser@^15.2.2":
+  version "15.2.2"
+  resolved "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.2.2.tgz"
+  integrity sha512-54fvjSwWiBTdVviiUItOCeyxtPSBmCrSEjlOl8XFEDuYD3lXY1lOBWKim/WJ3i1EYzdGx6rSOjK5KRDMppLI4Q==
+  dependencies:
+    js-yaml "^4.1.1"
 
 "@apidevtools/openapi-schemas@^2.1.0":
   version "2.1.0"
@@ -58,15 +58,175 @@
     "@biomejs/cli-win32-arm64" "2.4.4"
     "@biomejs/cli-win32-x64" "2.4.4"
 
+"@biomejs/cli-darwin-arm64@2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.4.tgz#a8af5254fcc9dda28a1da26125427df083a13579"
+  integrity sha512-jZ+Xc6qvD6tTH5jM6eKX44dcbyNqJHssfl2nnwT6vma6B1sj7ZLTGIk6N5QwVBs5xGN52r3trk5fgd3sQ9We9A==
+
+"@biomejs/cli-darwin-x64@2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.4.tgz#6de17d5bb3afaf3275bc602fb7e61fefe31dab84"
+  integrity sha512-Dh1a/+W+SUCXhEdL7TiX3ArPTFCQKJTI1mGncZNWfO+6suk+gYA4lNyJcBB+pwvF49uw0pEbUS49BgYOY4hzUg==
+
+"@biomejs/cli-linux-arm64-musl@2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.4.tgz#4c55afe87d555782f46e729212acd4e0411b1703"
+  integrity sha512-+sPAXq3bxmFwhVFJnSwkSF5Rw2ZAJMH3MF6C9IveAEOdSpgajPhoQhbbAK12SehN9j2QrHpk4J/cHsa/HqWaYQ==
+
+"@biomejs/cli-linux-arm64@2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.4.tgz#2c8848461bd5195d3e887b0c9fc9c1b441c727ec"
+  integrity sha512-V/NFfbWhsUU6w+m5WYbBenlEAz8eYnSqRMDMAW3K+3v0tYVkNyZn8VU0XPxk/lOqNXLSCCrV7FmV/u3SjCBShg==
+
+"@biomejs/cli-linux-x64-musl@2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.4.tgz#f40336d8c1534887c7ef4198b2b4772aca702ee8"
+  integrity sha512-gGvFTGpOIQDb5CQ2VC0n9Z2UEqlP46c4aNgHmAMytYieTGEcfqhfCFnhs6xjt0S3igE6q5GLuIXtdQt3Izok+g==
+
 "@biomejs/cli-linux-x64@2.4.4":
   version "2.4.4"
   resolved "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.4.tgz"
   integrity sha512-R4+ZCDtG9kHArasyBO+UBD6jr/FcFCTH8QkNTOCu0pRJzCWyWC4EtZa2AmUZB5h3e0jD7bRV2KvrENcf8rndBg==
 
+"@biomejs/cli-win32-arm64@2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.4.tgz#7d767c15ce20ee39bc1430c2057ccd0208cf12fe"
+  integrity sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q==
+
+"@biomejs/cli-win32-x64@2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.4.tgz#998e87083ff9657a24b4b2f6afcb803a2e820000"
+  integrity sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A==
+
+"@esbuild/aix-ppc64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz#815b39267f9bffd3407ea6c376ac32946e24f8d2"
+  integrity sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==
+
+"@esbuild/android-arm64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz#19b882408829ad8e12b10aff2840711b2da361e8"
+  integrity sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==
+
+"@esbuild/android-arm@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.3.tgz#90be58de27915efa27b767fcbdb37a4470627d7b"
+  integrity sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==
+
+"@esbuild/android-x64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.3.tgz#d7dcc976f16e01a9aaa2f9b938fbec7389f895ac"
+  integrity sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==
+
+"@esbuild/darwin-arm64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz#9f6cac72b3a8532298a6a4493ed639a8988e8abd"
+  integrity sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==
+
+"@esbuild/darwin-x64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz#ac61d645faa37fd650340f1866b0812e1fb14d6a"
+  integrity sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==
+
+"@esbuild/freebsd-arm64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz#b8625689d73cf1830fe58c39051acdc12474ea1b"
+  integrity sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==
+
+"@esbuild/freebsd-x64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz#07be7dd3c9d42fe0eccd2ab9f9ded780bc53bead"
+  integrity sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==
+
+"@esbuild/linux-arm64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz#bf31918fe5c798586460d2b3d6c46ed2c01ca0b6"
+  integrity sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==
+
+"@esbuild/linux-arm@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz#28493ee46abec1dc3f500223cd9f8d2df08f9d11"
+  integrity sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==
+
+"@esbuild/linux-ia32@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz#750752a8b30b43647402561eea764d0a41d0ee29"
+  integrity sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==
+
+"@esbuild/linux-loong64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz#a5a92813a04e71198c50f05adfaf18fc1e95b9ed"
+  integrity sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==
+
+"@esbuild/linux-mips64el@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz#deb45d7fd2d2161eadf1fbc593637ed766d50bb1"
+  integrity sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==
+
+"@esbuild/linux-ppc64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz#6f39ae0b8c4d3d2d61a65b26df79f6e12a1c3d78"
+  integrity sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==
+
+"@esbuild/linux-riscv64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz#4c5c19c3916612ec8e3915187030b9df0b955c1d"
+  integrity sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==
+
+"@esbuild/linux-s390x@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz#9ed17b3198fa08ad5ccaa9e74f6c0aff7ad0156d"
+  integrity sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==
+
 "@esbuild/linux-x64@0.27.3":
   version "0.27.3"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz"
   integrity sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==
+
+"@esbuild/netbsd-arm64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz#dd0cb2fa543205fcd931df44f4786bfcce6df7d7"
+  integrity sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==
+
+"@esbuild/netbsd-x64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz#028ad1807a8e03e155153b2d025b506c3787354b"
+  integrity sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==
+
+"@esbuild/openbsd-arm64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz#e3c16ff3490c9b59b969fffca87f350ffc0e2af5"
+  integrity sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==
+
+"@esbuild/openbsd-x64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz#c5a4693fcb03d1cbecbf8b422422468dfc0d2a8b"
+  integrity sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==
+
+"@esbuild/openharmony-arm64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz#082082444f12db564a0775a41e1991c0e125055e"
+  integrity sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==
+
+"@esbuild/sunos-x64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz#5ab036c53f929e8405c4e96e865a424160a1b537"
+  integrity sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==
+
+"@esbuild/win32-arm64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz#38de700ef4b960a0045370c171794526e589862e"
+  integrity sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==
+
+"@esbuild/win32-ia32@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz#451b93dc03ec5d4f38619e6cd64d9f9eff06f55c"
+  integrity sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==
+
+"@esbuild/win32-x64@0.27.3":
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz#0eaf705c941a218a43dba8e09f1df1d6cd2f1f17"
+  integrity sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==
 
 "@google/generative-ai@^0.24.1":
   version "0.24.1"
@@ -164,10 +324,130 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@rollup/rollup-android-arm-eabi@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz#add5e608d4e7be55bc3ca3d962490b8b1890e088"
+  integrity sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==
+
+"@rollup/rollup-android-arm64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz#10bd0382b73592beee6e9800a69401a29da625c4"
+  integrity sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==
+
+"@rollup/rollup-darwin-arm64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz#1e99ab04c0b8c619dd7bbde725ba2b87b55bfd81"
+  integrity sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==
+
+"@rollup/rollup-darwin-x64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz#69e741aeb2839d2e8f0da2ce7a33d8bd23632423"
+  integrity sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==
+
+"@rollup/rollup-freebsd-arm64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz#3736c232a999c7bef7131355d83ebdf9651a0839"
+  integrity sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==
+
+"@rollup/rollup-freebsd-x64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz#227dcb8f466684070169942bd3998901c9bfc065"
+  integrity sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz#ba004b30df31b724f99ce66e7128248bea17cb0c"
+  integrity sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==
+
+"@rollup/rollup-linux-arm-musleabihf@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz#6929f3e07be6b6da5991f63c6b68b3e473d0a65a"
+  integrity sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==
+
+"@rollup/rollup-linux-arm64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz#06e89fd4a25d21fe5575d60b6f913c0e65297bfa"
+  integrity sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==
+
+"@rollup/rollup-linux-arm64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz#fddabf395b90990d5194038e6cd8c00156ed8ac0"
+  integrity sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==
+
+"@rollup/rollup-linux-loong64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz#04c10bb764bbf09a3c1bd90432e92f58d6603c36"
+  integrity sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==
+
+"@rollup/rollup-linux-loong64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz#f2450361790de80581d8687ea19142d8a4de5c0f"
+  integrity sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==
+
+"@rollup/rollup-linux-ppc64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz#0474f4667259e407eee1a6d38e29041b708f6a30"
+  integrity sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==
+
+"@rollup/rollup-linux-ppc64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz#9f32074819eeb1ddbe51f50ea9dcd61a6745ec33"
+  integrity sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==
+
+"@rollup/rollup-linux-riscv64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz#3fdb9d4b1e29fb6b6a6da9f15654d42eb77b99b2"
+  integrity sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==
+
+"@rollup/rollup-linux-riscv64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz#1de780d64e6be0e3e8762035c22e0d8ea68df8ed"
+  integrity sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==
+
+"@rollup/rollup-linux-s390x-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz#1da022ffd2d9e9f0fd8344ea49e113001fbcac64"
+  integrity sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==
+
 "@rollup/rollup-linux-x64-gnu@4.57.1":
   version "4.57.1"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz"
   integrity sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==
+
+"@rollup/rollup-linux-x64-musl@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz#a7598591b4d9af96cb3167b50a5bf1e02dfea06c"
+  integrity sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==
+
+"@rollup/rollup-openbsd-x64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz#c51d48c07cd6c466560e5bed934aec688ce02614"
+  integrity sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==
+
+"@rollup/rollup-openharmony-arm64@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz#f09921d0b2a0b60afbf3586d2a7a7f208ba6df17"
+  integrity sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==
+
+"@rollup/rollup-win32-arm64-msvc@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz#08d491717135376e4a99529821c94ecd433d5b36"
+  integrity sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==
+
+"@rollup/rollup-win32-ia32-msvc@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz#b0c12aac1104a8b8f26a5e0098e5facbb3e3964a"
+  integrity sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==
+
+"@rollup/rollup-win32-x64-gnu@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz#b9cccef26f5e6fdc013bf3c0911a3c77428509d0"
+  integrity sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==
+
+"@rollup/rollup-win32-x64-msvc@4.57.1":
+  version "4.57.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz#a03348e7b559c792b6277cc58874b89ef46e1e72"
+  integrity sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==
 
 "@standard-schema/spec@^1.0.0":
   version "1.1.0"
@@ -197,7 +477,7 @@
   resolved "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
-"@types/estree@^1.0.0", "@types/estree@1.0.8":
+"@types/estree@1.0.8", "@types/estree@^1.0.0":
   version "1.0.8"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
@@ -207,7 +487,7 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/node@^20.0.0 || ^22.0.0 || >=24.0.0", "@types/node@^20.19.0 || >=22.12.0", "@types/node@>=13.7.0":
+"@types/node@>=13.7.0":
   version "25.3.0"
   resolved "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz"
   integrity sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==
@@ -304,7 +584,7 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
-ajv@^8.0.0, ajv@^8.17.1, ajv@^8.18.0, ajv@^8.5.0:
+ajv@^8.0.0, ajv@^8.17.1, ajv@^8.18.0:
   version "8.18.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
@@ -632,15 +912,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 colorette@2.0.19:
   version "2.0.19"
@@ -681,17 +961,17 @@ cookie-parser@^1.4.7:
     cookie "0.7.2"
     cookie-signature "1.0.6"
 
-cookie-signature@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz"
-  integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
-
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
-cookie@^0.7.1, cookie@0.7.2:
+cookie-signature@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz"
+  integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
+
+cookie@0.7.2, cookie@^0.7.1:
   version "0.7.2"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
@@ -744,7 +1024,7 @@ db-errors@^0.2.3:
   resolved "https://registry.npmjs.org/db-errors/-/db-errors-0.2.3.tgz"
   integrity sha512-OOgqgDuCavHXjYSJoV2yGhv6SeG8nk42aoCSoyXLZUH7VwFG27rxbavU1z+VrZbZjphw5UkDQwUlD21MwZpUng==
 
-debug@^4.1.1, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3, debug@4:
+debug@4, debug@^4.1.1, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -1029,7 +1309,7 @@ express-rate-limit@8.2.1:
   dependencies:
     ip-address "10.0.1"
 
-"express@>= 4.11", express@5.2.1:
+express@5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/express/-/express-5.2.1.tgz"
   integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
@@ -1136,6 +1416,11 @@ fs-constants@^1.0.0:
   resolved "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
+fsevents@~2.3.2, fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -1201,7 +1486,7 @@ github-from-package@0.0.0:
   resolved "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz"
   integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
-glob@^13.0.6:
+glob@^10.0.0, glob@^13.0.6:
   version "13.0.6"
   resolved "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz"
   integrity sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==
@@ -1300,15 +1585,15 @@ ignore@^5.1.4:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
 inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
   integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
+
+inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ini@~1.3.0:
   version "1.3.8"
@@ -1320,20 +1605,20 @@ interpret@^2.2.0:
   resolved "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-ip-address@^10.0.1, ip-address@10.0.1:
+ip-address@10.0.1, ip-address@^10.0.1:
   version "10.0.1"
   resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz"
   integrity sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==
-
-ipaddr.js@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz"
-  integrity sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+ipaddr.js@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz"
+  integrity sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -1466,7 +1751,7 @@ jws@^4.0.1:
     jwa "^2.0.1"
     safe-buffer "^5.0.1"
 
-knex@>=1.0.1, knex@3.1.0:
+knex@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/knex/-/knex-3.1.0.tgz"
   integrity sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==
@@ -1622,7 +1907,7 @@ mimic-response@^3.1.0:
   resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
-minimatch@^10.2.1:
+minimatch@^10.2.1, minimatch@^10.2.2, minimatch@^5.1.0:
   version "10.2.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz"
   integrity sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==
@@ -1656,15 +1941,15 @@ mri@^1.2.0:
   resolved "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
-ms@^2.1.1, ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.1, ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 mysql2@^3.17.4:
   version "3.17.4"
@@ -1769,7 +2054,7 @@ once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-openapi-types@^12.1.3, openapi-types@>=7:
+openapi-types@^12.1.3:
   version "12.1.3"
   resolved "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz"
   integrity sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==
@@ -1887,15 +2172,15 @@ pg-cloudflare@^1.3.0:
   resolved "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz"
   integrity sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==
 
-pg-connection-string@^2.11.0:
-  version "2.11.0"
-  resolved "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz"
-  integrity sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==
-
 pg-connection-string@2.6.2:
   version "2.6.2"
   resolved "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz"
   integrity sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==
+
+pg-connection-string@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz"
+  integrity sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==
 
 pg-int8@1.0.1:
   version "1.0.1"
@@ -1923,7 +2208,7 @@ pg-types@2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.17.2, pg@>=8.0:
+pg@^8.17.2:
   version "8.18.0"
   resolved "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz"
   integrity sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==
@@ -1948,7 +2233,7 @@ picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-"picomatch@^3 || ^4", picomatch@^4.0.3:
+picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
@@ -2093,7 +2378,7 @@ punycode.js@2.3.1:
   resolved "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz"
   integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
-qs@>=6.14.2:
+qs@>=6.14.2, qs@^6.14.0, qs@^6.14.1:
   version "6.15.0"
   resolved "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz"
   integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
@@ -2138,25 +2423,7 @@ readable-stream@^2.0.5:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1:
-  version "3.6.2"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
-  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
-readable-stream@^3.4.0:
-  version "3.6.2"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
-  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
-readable-stream@^3.5.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0:
   version "3.6.2"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -2499,6 +2766,15 @@ streamx@^2.15.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string_decoder@^1.1.1, string_decoder@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
@@ -2512,15 +2788,6 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -2750,7 +3017,7 @@ vary@^1.1.2:
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-"vite@^6.0.0 || ^7.0.0", "vite@^6.0.0 || ^7.0.0-0":
+"vite@^6.0.0 || ^7.0.0":
   version "7.3.1"
   resolved "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz"
   integrity sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==


### PR DESCRIPTION
This PR adds a significant number of unit tests for the backend codebase, covering both utility libraries (`backend/lib`) and core internal logic (`backend/internal`).

Key changes:
- Created new test files for `utils.js`, `encryption.js`, `error.js`, `service-icons.js`, `nginx.js`, and `token.js`.
- Implemented robust mocking for external dependencies including `node:fs`, `node:child_process`, `bcryptjs`, and database models.
- Fixed an issue in `certificate.test.js` where `node:fs` was not being mocked correctly for default imports, causing tests to fail when `config.js` attempted to access the filesystem.
- Verified all tests pass with `npm test`.

This improves test coverage and ensures stability for core functions.

---
*PR created automatically by Jules for task [14081996654709715662](https://jules.google.com/task/14081996654709715662) started by @shedowe19*