### PR TITLE
chore(ci): consolidate npm dependency updates and notices generation

### DIFF
--- a/.github/workflows/npm-updates.yml
+++ b/.github/workflows/npm-updates.yml
@@ -2,8 +2,9 @@ name: NPM Dependency Updates
 
 on:
   schedule:
+    # Run everyday at midnight
     - cron: "0 0 * * *"
-  workflow_dispatch:
+  workflow_dispatch: # Allow manual triggering
 
 permissions:
   contents: write
@@ -12,11 +13,8 @@ permissions:
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        directory: [frontend, backend]
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Setup Node.js
@@ -24,14 +22,64 @@ jobs:
         with:
           node-version: 22
           cache: "yarn"
-          cache-dependency-path: ./${{ matrix.directory }}/yarn.lock
+          # Cache both frontend and backend yarn.lock to speed up installs
+          cache-dependency-path: |
+            frontend/yarn.lock
+            backend/yarn.lock
 
-      - name: Update Dependencies (Minor/Patch)
-        working-directory: ./${{ matrix.directory }}
+      - name: Update Frontend Dependencies
+        working-directory: ./frontend
         run: |
+          echo "Installing current frontend dependencies..."
           yarn install
-          npx npm-check-updates -u --target minor
+
+          echo "Checking for minor/patch updates..."
+          echo "### Frontend Updates" > ../frontend-updates.txt
+          echo '```text' >> ../frontend-updates.txt
+          # Run npm-check-updates, update package.json, and capture the output
+          # -u: upgrade package.json
+          # --target minor: only upgrade to minor/patch versions, ignoring major
+          npx npm-check-updates -u --target minor >> ../frontend-updates.txt || true
+          echo '```' >> ../frontend-updates.txt
+
+          echo "Installing updated frontend dependencies to update yarn.lock..."
           yarn install
+
+      - name: Update Backend Dependencies
+        working-directory: ./backend
+        run: |
+          echo "Installing current backend dependencies..."
+          yarn install
+
+          echo "Checking for minor/patch updates..."
+          echo "### Backend Updates" > ../backend-updates.txt
+          echo '```text' >> ../backend-updates.txt
+          # Run npm-check-updates, update package.json, and capture the output
+          # -u: upgrade package.json
+          # --target minor: only upgrade to minor/patch versions, ignoring major
+          npx npm-check-updates -u --target minor >> ../backend-updates.txt || true
+          echo '```' >> ../backend-updates.txt
+
+          echo "Installing updated backend dependencies to update yarn.lock..."
+          yarn install
+
+      - name: Generate Third-Party Notices
+        run: |
+          echo "Generating updated THIRD-PARTY-NOTICES.md..."
+          # Run the generate-notices.js script to update the license notices
+          node scripts/generate-notices.js
+
+      - name: Prepare PR Body
+        run: |
+          echo "## Automated Dependency Updates" > pr_body.txt
+          echo "This PR updates both frontend and backend dependencies to their latest **minor** and **patch** versions." >> pr_body.txt
+          echo "" >> pr_body.txt
+          cat frontend-updates.txt >> pr_body.txt
+          echo "" >> pr_body.txt
+          cat backend-updates.txt >> pr_body.txt
+          echo "" >> pr_body.txt
+          echo "### Additional Actions" >> pr_body.txt
+          echo "- Ran \`scripts/generate-notices.js\` to update \`THIRD-PARTY-NOTICES.md\` to reflect these changes." >> pr_body.txt
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
@@ -39,7 +87,7 @@ jobs:
           base: "develop"
           signoff: true
           delete-branch: true
-          commit-message: "chore(deps): update ${{ matrix.directory }} dependencies (minor/patch)"
-          branch: "update-${{ matrix.directory }}-deps"
-          title: "chore(deps): update ${{ matrix.directory }} dependencies (minor/patch)"
-          body: "Automated ${{ matrix.directory }} dependency updates (minor and patch versions only)."
+          commit-message: "chore(deps): update frontend and backend dependencies (minor/patch)"
+          branch: "update-all-deps"
+          title: "chore(deps): update npm dependencies (minor/patch)"
+          body-path: pr_body.txt

--- a/backend/internal/oauth2-proxy.js
+++ b/backend/internal/oauth2-proxy.js
@@ -1,6 +1,5 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
-
 import { global as logger } from "../logger.js";
 import AccessList from "../models/access_list.js";
 import ProxyHost from "../models/proxy_host.js";

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -22,18 +22,18 @@ import { T } from "src/locale";
 import {
 	ACCESS_LISTS,
 	ADMIN,
+	ANALYTICS,
 	CERTIFICATES,
+	CLOUDFLARED_TUNNELS,
+	DDNS_PROVIDERS,
 	DEAD_HOSTS,
 	type MANAGE,
 	PROXY_HOSTS,
 	REDIRECTION_HOSTS,
 	type Section,
 	STREAMS,
-	VIEW,
-	CLOUDFLARED_TUNNELS,
-	ANALYTICS,
-	DDNS_PROVIDERS,
 	TOR_ONIONS,
+	VIEW,
 } from "src/modules/Permissions";
 
 interface MenuItem {

--- a/frontend/src/modals/PermissionsModal.tsx
+++ b/frontend/src/modals/PermissionsModal.tsx
@@ -2,15 +2,15 @@ import {
 	IconArrowsRightLeft,
 	IconBolt,
 	IconBoltOff,
+	IconChartBar,
+	IconCloud,
 	IconDisc,
 	IconEye,
-	IconLock,
-	IconShield,
-	IconCloud,
-	IconChartBar,
-	IconServer,
-	IconNetwork,
 	IconFileText,
+	IconLock,
+	IconNetwork,
+	IconServer,
+	IconShield,
 } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import EasyModal, { type InnerModalProps } from "ez-modal-react";

--- a/frontend/src/pages/Nginx/CloudflaredTunnels.tsx
+++ b/frontend/src/pages/Nginx/CloudflaredTunnels.tsx
@@ -3,6 +3,7 @@ import dayjs from "dayjs";
 import { Cloud, Lock } from "lucide-react";
 import { useMemo, useState } from "react";
 import type { CloudflaredTunnel } from "@/api/backend";
+import { HasPermission } from "@/components/HasPermission";
 import { CloudflaredTunnelModal } from "@/components/Nginx/CloudflaredTunnelModal";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -12,7 +13,6 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { useCloudflaredTunnel, useCloudflaredTunnels } from "@/hooks/useCloudflaredTunnel";
 import { useHealth } from "@/hooks/useHealth";
 import { T } from "@/locale";
-import { HasPermission } from "@/components/HasPermission";
 import { showHelpModal } from "@/modals";
 import { CLOUDFLARED_TUNNELS, MANAGE } from "@/modules/Permissions";
 

--- a/frontend/src/pages/Nginx/DdnsProviders/Table.tsx
+++ b/frontend/src/pages/Nginx/DdnsProviders/Table.tsx
@@ -3,6 +3,7 @@ import { createColumnHelper, getCoreRowModel, useReactTable } from "@tanstack/re
 import { useMemo } from "react";
 import type { DdnsProvider } from "src/api/backend";
 import { EmptyData } from "src/components";
+import { HasPermission } from "src/components/HasPermission";
 import { TableLayout } from "src/components/Table/TableLayout";
 import { Badge } from "src/components/ui/badge";
 import { Button } from "src/components/ui/button";
@@ -15,9 +16,8 @@ import {
 	DropdownMenuTrigger,
 } from "src/components/ui/dropdown-menu";
 import { intl, T } from "src/locale";
-import { AUDIT_LOG_OBJECT_TYPE } from "src/types/enums";
-import { HasPermission } from "src/components/HasPermission";
 import { DDNS_PROVIDERS, MANAGE } from "src/modules/Permissions";
+import { AUDIT_LOG_OBJECT_TYPE } from "src/types/enums";
 
 interface Props {
 	data: DdnsProvider[];

--- a/frontend/src/pages/Nginx/DdnsProviders/TableWrapper.tsx
+++ b/frontend/src/pages/Nginx/DdnsProviders/TableWrapper.tsx
@@ -4,16 +4,16 @@ import { AlertCircle } from "lucide-react";
 import { useState } from "react";
 import { deleteDdnsProvider, getDdnsProviders } from "src/api/backend";
 import { LoadingPage } from "src/components";
+import { HasPermission } from "src/components/HasPermission";
 import { Alert, AlertDescription, AlertTitle } from "src/components/ui/alert";
 import { Button } from "src/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "src/components/ui/card";
 import { Input } from "src/components/ui/input";
 import { intl, T } from "src/locale";
 import { showDdnsProviderModal, showDeleteConfirmModal, showHelpModal } from "src/modals";
+import { DDNS_PROVIDERS, MANAGE } from "src/modules/Permissions";
 import { showObjectSuccess } from "src/notifications";
 import { AUDIT_LOG_OBJECT_TYPE } from "src/types/enums";
-import { HasPermission } from "src/components/HasPermission";
-import { DDNS_PROVIDERS, MANAGE } from "src/modules/Permissions";
 import Table from "./Table";
 
 export default function TableWrapper() {

--- a/frontend/src/pages/Nginx/TorOnionServices.tsx
+++ b/frontend/src/pages/Nginx/TorOnionServices.tsx
@@ -12,6 +12,7 @@ import { AlertCircle, Lock } from "lucide-react";
 import { useState } from "react";
 import { BADGE_VARIANT, type BadgeVariant, TOR_ONION_STATUS, type TorOnionStatus } from "src/types/enums";
 import type { TorOnion } from "@/api/backend";
+import { HasPermission } from "@/components/HasPermission";
 import { TorOnionModal } from "@/components/Nginx/TorOnionModal";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -22,7 +23,6 @@ import { useToast } from "@/hooks/use-toast";
 import { useHealth } from "@/hooks/useHealth";
 import { useTorOnion, useTorOnions } from "@/hooks/useTorOnion";
 import { T } from "@/locale";
-import { HasPermission } from "@/components/HasPermission";
 import { showHelpModal } from "@/modals";
 import { MANAGE, TOR_ONIONS } from "@/modules/Permissions";
 


### PR DESCRIPTION
This PR updates the GitHub Actions workflow responsible for NPM updates. It simplifies the workflow to use a single sequential job instead of a matrix job, creating just one Pull Request with updates for both the frontend and backend. Additionally, the workflow now automatically updates `THIRD-PARTY-NOTICES.md` by calling `scripts/generate-notices.js` and provides a nicely formatted PR body describing all changes. This fulfills the user's request for "not 2 PRs" and "well documented what was updated".

---
*PR created automatically by Jules for task [742344295858088337](https://jules.google.com/task/742344295858088337) started by @shedowe19*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update workflow with manual trigger capability and better PR summaries combining frontend and backend updates.
  * Consolidated and reorganized imports across frontend components for consistency.
  * Minor code formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->