### PR TITLE
fix: invalid absolute path in tempWrite for certificates

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -635,7 +635,7 @@ const internalCertificate = {
 	 * @param {String}  privateKey    This is the entire key contents as a string
 	 */
 	checkPrivateKey: async (privateKey) => {
-		const filepath = await tempWrite(privateKey, "/tmp");
+		const filepath = await tempWrite(privateKey, "key.pem");
 		const failTimeout = setTimeout(() => {
 			throw new error.ValidationError(
 				"Result Validation Error: Validation timed out. This could be due to the key being passphrase-protected.",
@@ -667,7 +667,7 @@ const internalCertificate = {
 	getCertificateInfo: async (certificate, throwExpired) => {
 		let filepath = null;
 		try {
-			filepath = await tempWrite(certificate, "/tmp");
+			filepath = await tempWrite(certificate, "cert.pem");
 			const certData = await internalCertificate.getCertificateInfoFromFile(filepath, throwExpired);
 			fs.unlinkSync(filepath);
 			return certData;


### PR DESCRIPTION
Fixes a crash when adding custom certificates or checking keys, caused by using `"/tmp"` as an absolute path in the `tempWrite` function in `backend/internal/certificate.js`. The `temp-write` library enforces relative paths for the filename suffix. Replaced with `"key.pem"` and `"cert.pem"`.

---
*PR created automatically by Jules for task [6318168334325025641](https://jules.google.com/task/6318168334325025641) started by @shedowe19*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced TLS certificate and private key validation through improved temporary file handling to increase reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->