### PR TITLE
fix: parse and store Subject Alternative Names (SANs) from custom certificates

### DIFF
--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -618,7 +618,7 @@ const internalCertificate = {
 				expires_on: /** @type {any} */ (
 					dayjs.unix(validations.certificate.dates.to).format("YYYY-MM-DD HH:mm:ss")
 				),
-				domain_names: [validations.certificate.cn],
+				domain_names: Array.from(new Set([validations.certificate.cn, ...(validations.certificate.sans || [])])),
 				meta: _.clone(row.meta), // Prevent the update method from changing this value that we'll use later
 			}),
 		);
@@ -709,6 +709,32 @@ const internalCertificate = {
 			const match2 = regex2.exec(result2);
 			if (match2 && typeof match2[1] !== "undefined") {
 				certData.issuer = match2[1];
+			}
+
+			certData.sans = [];
+			try {
+				const resultSans = await utils.execFile("openssl", [
+					"x509",
+					"-in",
+					certificateFile,
+					"-ext",
+					"subjectAltName",
+					"-noout",
+				]);
+				const linesSans = resultSans.split("\n");
+				for (const line of linesSans) {
+					if (line.includes("DNS:")) {
+						const parts = line.split(",");
+						for (const part of parts) {
+							const trimmed = part.trim();
+							if (trimmed.startsWith("DNS:")) {
+								certData.sans.push(trimmed.substring(4));
+							}
+						}
+					}
+				}
+			} catch (err) {
+				// Certificate might not have SANs, ignore error
 			}
 
 			const result3 = await utils.execFile("openssl", ["x509", "-in", certificateFile, "-dates", "-noout"]);

--- a/backend/internal/certificate.js
+++ b/backend/internal/certificate.js
@@ -618,7 +618,9 @@ const internalCertificate = {
 				expires_on: /** @type {any} */ (
 					dayjs.unix(validations.certificate.dates.to).format("YYYY-MM-DD HH:mm:ss")
 				),
-				domain_names: Array.from(new Set([validations.certificate.cn, ...(validations.certificate.sans || [])])),
+				domain_names: Array.from(
+					new Set([validations.certificate.cn, ...(validations.certificate.sans || [])]),
+				),
 				meta: _.clone(row.meta), // Prevent the update method from changing this value that we'll use later
 			}),
 		);


### PR DESCRIPTION
Fixes an issue where uploaded custom certificates did not parse or store their Subject Alternative Names (SANs). 

This meant that certificates with wildcard SANs (e.g. `*.clawsucht.eu` as shown in the user's issue description) would only register under their primary Common Name, breaking association for the wildcard subdomains.

The `getCertificateInfoFromFile` parsing function now queries OpenSSL for the `subjectAltName` extension and extracts `DNS:` entries. The `upload` controller then combines the CN and SANs into a deduplicated array for the `domain_names` property in the database.

---
*PR created automatically by Jules for task [12363573365666750153](https://jules.google.com/task/12363573365666750153) started by @shedowe19*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced certificate upload for non-standard providers to now recognize and apply all domain names from certificates, including Subject Alternative Names (SANs), rather than only the primary domain name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->