### PR TITLE
style: style custom certificate file upload inputs and update translation key

### DIFF
--- a/frontend/src/locale/lang/bg.json
+++ b/frontend/src/locale/lang/bg.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "Кеширането е активирано",
 	"cancel": "Отказ",
 	"certificate": "Сертификат",
+	"certificate.custom": "Потребителски сертификат",
 	"certificate.custom-certificate": "Сертификат",
 	"certificate.custom-certificate-key": "Ключ на сертификата",
 	"certificate.custom-intermediate": "Междинен сертификат",

--- a/frontend/src/locale/lang/de.json
+++ b/frontend/src/locale/lang/de.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "Caching aktiviert",
 	"cancel": "Abbrechen",
 	"certificate": "Zertifikat",
+	"certificate.custom": "Benutzerdefiniertes Zertifikat",
 	"certificate.custom-certificate": "Zertifikat",
 	"certificate.custom-certificate-key": "Privater Schlüssel",
 	"certificate.custom-intermediate": "Zwischen Zertifikat",

--- a/frontend/src/locale/lang/en.json
+++ b/frontend/src/locale/lang/en.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "Caching Enabled",
 	"cancel": "Cancel",
 	"certificate": "Certificate",
+	"certificate.custom": "Custom Certificate",
 	"certificate.custom-certificate": "Certificate",
 	"certificate.custom-certificate-key": "Certificate Key",
 	"certificate.custom-intermediate": "Intermediate Certificate",

--- a/frontend/src/locale/lang/es.json
+++ b/frontend/src/locale/lang/es.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "Caché habilitada",
 	"cancel": "Cancelar",
 	"certificate": "Certificado",
+	"certificate.custom": "Certificado Personalizado",
 	"certificate.custom-certificate": "Certificado",
 	"certificate.custom-certificate-key": "Clave del Certificado",
 	"certificate.custom-intermediate": "Certificado Intermedio",

--- a/frontend/src/locale/lang/it.json
+++ b/frontend/src/locale/lang/it.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "Cache abilitata",
 	"cancel": "Annulla",
 	"certificate": "Certificato",
+	"certificate.custom": "Certificato Personalizzato",
 	"certificate.custom-certificate": "Certificato",
 	"certificate.custom-certificate-key": "Chiave del Certificato",
 	"certificate.custom-intermediate": "Certificato Intermedio",

--- a/frontend/src/locale/lang/ja.json
+++ b/frontend/src/locale/lang/ja.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "キャッシュが有効",
 	"cancel": "キャンセル",
 	"certificate": "証明書",
+	"certificate.custom": "カスタム証明書",
 	"certificate.custom-certificate": "証明書",
 	"certificate.custom-certificate-key": "証明書キー",
 	"certificate.custom-intermediate": "中間証明書",

--- a/frontend/src/locale/lang/ko.json
+++ b/frontend/src/locale/lang/ko.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "캐싱 활성화됨",
 	"cancel": "취소",
 	"certificate": "인증서",
+	"certificate.custom": "사용자 지정 인증서",
 	"certificate.custom-certificate": "인증서",
 	"certificate.custom-certificate-key": "인증서 키",
 	"certificate.custom-intermediate": "중간 인증서",

--- a/frontend/src/locale/lang/nl.json
+++ b/frontend/src/locale/lang/nl.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "Caching Ingeschakeld",
 	"cancel": "Annuleren",
 	"certificate": "Certificaat",
+	"certificate.custom": "Aangepast Certificaat",
 	"certificate.custom-certificate": "Certificaat",
 	"certificate.custom-certificate-key": "Certificaat Sleutel",
 	"certificate.custom-intermediate": "Intermediate Certificaat",

--- a/frontend/src/locale/lang/pl.json
+++ b/frontend/src/locale/lang/pl.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "Buforowanie włączone",
 	"cancel": "Anuluj",
 	"certificate": "Certyfikat",
+	"certificate.custom": "Certyfikat własny",
 	"certificate.custom-certificate": "Certyfikat",
 	"certificate.custom-certificate-key": "Klucz certyfikatu",
 	"certificate.custom-intermediate": "Certyfikat pośredni",

--- a/frontend/src/locale/lang/ru.json
+++ b/frontend/src/locale/lang/ru.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "Кэширование включено",
 	"cancel": "Отменить",
 	"certificate": "Сертификат",
+	"certificate.custom": "Свой сертификат",
 	"certificate.custom-certificate": "Сертификат",
 	"certificate.custom-certificate-key": "Ключ сертификата",
 	"certificate.custom-intermediate": "Промежуточный сертификат",

--- a/frontend/src/locale/lang/sk.json
+++ b/frontend/src/locale/lang/sk.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "Ukladanie do vyrovnávacej pamäte povolené",
 	"cancel": "Zrušiť",
 	"certificate": "Certifikát",
+	"certificate.custom": "Vlastný certifikát",
 	"certificate.custom-certificate": "Certifikát",
 	"certificate.custom-certificate-key": "Kľúč certifikátu",
 	"certificate.custom-intermediate": "Sprostredkovateľský certifikát",

--- a/frontend/src/locale/lang/vi.json
+++ b/frontend/src/locale/lang/vi.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "Đã bật bộ nhớ đệm",
 	"cancel": "Hủy",
 	"certificate": "Chứng chỉ",
+	"certificate.custom": "Chứng chỉ tùy chỉnh",
 	"certificate.custom-certificate": "Certificate (crt)",
 	"certificate.custom-certificate-key": "Certificate Key",
 	"certificate.custom-intermediate": "Intermediate Certificate",

--- a/frontend/src/locale/lang/zh.json
+++ b/frontend/src/locale/lang/zh.json
@@ -142,6 +142,7 @@
 	"cachingEnabled": "已启用缓存",
 	"cancel": "取消",
 	"certificate": "证书",
+	"certificate.custom": "自定义证书",
 	"certificate.custom-certificate": "证书",
 	"certificate.custom-certificate-key": "证书密钥",
 	"certificate.custom-intermediate": "中间证书",

--- a/frontend/src/modals/CustomCertificateModal.tsx
+++ b/frontend/src/modals/CustomCertificateModal.tsx
@@ -191,7 +191,7 @@ const CustomCertificateModal = EasyModal.create(({ visible, remove }: InnerModal
 													id="certificateKey"
 													type="file"
 													required={mode === CERT_CUSTOM_MODE.UPLOAD}
-													className={`cursor-pointer file:text-foreground ${errors.certificateKey && touched.certificateKey ? "border-destructive" : ""}`}
+													className={`cursor-pointer file:mr-4 file:py-1 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-primary-foreground hover:file:bg-primary/90 ${errors.certificateKey && touched.certificateKey ? "border-destructive" : ""}`}
 													onChange={(event) => {
 														setFieldValue(
 															"certificateKey",
@@ -211,7 +211,7 @@ const CustomCertificateModal = EasyModal.create(({ visible, remove }: InnerModal
 													id="certificate"
 													type="file"
 													required={mode === CERT_CUSTOM_MODE.UPLOAD}
-													className={`cursor-pointer file:text-foreground ${errors.certificate && touched.certificate ? "border-destructive" : ""}`}
+													className={`cursor-pointer file:mr-4 file:py-1 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-primary-foreground hover:file:bg-primary/90 ${errors.certificate && touched.certificate ? "border-destructive" : ""}`}
 													onChange={(event) => {
 														setFieldValue(
 															"certificate",
@@ -230,7 +230,7 @@ const CustomCertificateModal = EasyModal.create(({ visible, remove }: InnerModal
 												<Input
 													id="intermediateCertificate"
 													type="file"
-													className={`cursor-pointer file:text-foreground ${errors.intermediateCertificate && touched.intermediateCertificate ? "border-destructive" : ""}`}
+													className={`cursor-pointer file:mr-4 file:py-1 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-primary-foreground hover:file:bg-primary/90 ${errors.intermediateCertificate && touched.intermediateCertificate ? "border-destructive" : ""}`}
 													onChange={(event) => {
 														setFieldValue(
 															"intermediateCertificate",


### PR DESCRIPTION
This PR updates the "Datei auswählen" (File Upload) input elements within the Custom Certificate Modal to appear as native buttons, using Tailwind `file:` modifiers for a consistent UI.

It also addresses the missing translation strings for `certificate.custom`, ensuring it maps correctly across all supported localizations natively, avoiding the fallback logic.

Additional files (like `backend/yarn.lock` and `fix_locales.js`) were purposely excluded per user request.

---
*PR created automatically by Jules for task [17949799480219806246](https://jules.google.com/task/17949799480219806246) started by @shedowe19*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added "Custom Certificate" label translations across 12 languages, including Bulgarian, German, Spanish, Italian, Japanese, Korean, Dutch, Polish, Russian, Slovak, Vietnamese, and Chinese.

* **Style**
  * Enhanced file input styling in the Custom Certificate Modal with improved visual presentation, including button-like styling, spacing, rounded corners, and interactive hover states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->