### PR TITLE
fix: sort analytics recent requests by timestamp

### DIFF
--- a/backend/internal/user.js
+++ b/backend/internal/user.js
@@ -587,7 +587,7 @@ const internalUser = {
 	getAvatarImage: async (_access, data) => {
 		// Public access allowed for avatars, but we check existence
 		const user = await userModel.query().findById(data.id);
-		if (!user || user.avatar_type !== "upload" || !user.avatar_value) {
+		if (user?.avatar_type !== "upload" || !user.avatar_value) {
 			throw new errs.ItemNotFoundError("Avatar not found");
 		}
 

--- a/frontend/src/pages/Analytics/index.tsx
+++ b/frontend/src/pages/Analytics/index.tsx
@@ -19,6 +19,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "src/components/ui/card
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "src/components/ui/select";
 import { useHealth, useProxyHosts } from "src/hooks";
 import { T } from "src/locale";
+import { formatRecentRequestTime, sortRecentRequests } from "./utils";
 
 countries.registerLocale(enLocale);
 
@@ -70,7 +71,10 @@ const Analytics = () => {
 				const hostId = Number.parseInt(selectedHostId, 10);
 				// Fetch Summary
 				const summaryData = await getAnalyticsSummary(hostId, range);
-				setSummary(summaryData);
+				setSummary({
+					...summaryData,
+					recentRequests: sortRecentRequests(summaryData.recentRequests),
+				});
 
 				// Fetch Series
 				const seriesData = await getAnalyticsSeries(hostId, range);
@@ -620,7 +624,7 @@ const Analytics = () => {
 											key={`${req.time}-${req.ip}-${req.path}`}
 											className="border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
 										>
-											<td className="p-4 align-middle">{dayjs(req.time).format("HH:mm:ss")}</td>
+											<td className="p-4 align-middle whitespace-nowrap">{formatRecentRequestTime(req.time)}</td>
 											<td className="p-4 align-middle font-mono">{req.method}</td>
 											<td className="p-4 align-middle">
 												<span

--- a/frontend/src/pages/Analytics/index.tsx
+++ b/frontend/src/pages/Analytics/index.tsx
@@ -624,7 +624,9 @@ const Analytics = () => {
 											key={`${req.time}-${req.ip}-${req.path}`}
 											className="border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
 										>
-											<td className="p-4 align-middle whitespace-nowrap">{formatRecentRequestTime(req.time)}</td>
+											<td className="p-4 align-middle whitespace-nowrap">
+												{formatRecentRequestTime(req.time)}
+											</td>
 											<td className="p-4 align-middle font-mono">{req.method}</td>
 											<td className="p-4 align-middle">
 												<span

--- a/frontend/src/pages/Analytics/utils.test.ts
+++ b/frontend/src/pages/Analytics/utils.test.ts
@@ -1,0 +1,43 @@
+import dayjs from "dayjs";
+import { describe, expect, it } from "vitest";
+import type { AnalyticsRequestLog } from "src/api/backend";
+import { formatRecentRequestTime, sortRecentRequests } from "./utils";
+
+const makeRequest = (time: string): AnalyticsRequestLog => ({
+	time,
+	method: "GET",
+	status: 200,
+	path: "/",
+	ip: "127.0.0.1",
+	duration: 1,
+});
+
+describe("analytics recent request helpers", () => {
+	it("sorts recent requests by full timestamp descending", () => {
+		const requests = [
+			makeRequest("2026-06-10T01:32:48.000Z"),
+			makeRequest("2026-06-10T01:02:43.000Z"),
+			makeRequest("2026-06-10T01:52:02.000Z"),
+		];
+
+		const sorted = sortRecentRequests(requests);
+
+		expect(sorted.map((request) => request.time)).toEqual([
+			"2026-06-10T01:52:02.000Z",
+			"2026-06-10T01:32:48.000Z",
+			"2026-06-10T01:02:43.000Z",
+		]);
+		expect(requests.map((request) => request.time)).toEqual([
+			"2026-06-10T01:32:48.000Z",
+			"2026-06-10T01:02:43.000Z",
+			"2026-06-10T01:52:02.000Z",
+		]);
+	});
+
+	it("includes the date in recent request time labels", () => {
+		const value = "2026-06-10T01:52:02.000Z";
+
+		expect(formatRecentRequestTime(value)).toBe(dayjs(value).format("YYYY-MM-DD HH:mm:ss"));
+		expect(formatRecentRequestTime(value)).not.toBe(dayjs(value).format("HH:mm:ss"));
+	});
+});

--- a/frontend/src/pages/Analytics/utils.test.ts
+++ b/frontend/src/pages/Analytics/utils.test.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
-import { describe, expect, it } from "vitest";
 import type { AnalyticsRequestLog } from "src/api/backend";
+import { describe, expect, it } from "vitest";
 import { formatRecentRequestTime, sortRecentRequests } from "./utils";
 
 const makeRequest = (time: string): AnalyticsRequestLog => ({

--- a/frontend/src/pages/Analytics/utils.ts
+++ b/frontend/src/pages/Analytics/utils.ts
@@ -1,0 +1,15 @@
+import dayjs from "dayjs";
+import type { AnalyticsRequestLog } from "src/api/backend";
+
+const toTimestamp = (request: AnalyticsRequestLog): number => {
+	const timestamp = Date.parse(request.time);
+	return Number.isFinite(timestamp) ? timestamp : Number.NEGATIVE_INFINITY;
+};
+
+export const sortRecentRequests = (requests: AnalyticsRequestLog[] = []): AnalyticsRequestLog[] =>
+	[...requests].sort((left, right) => toTimestamp(right) - toTimestamp(left));
+
+export const formatRecentRequestTime = (time: string): string => {
+	const parsed = dayjs(time);
+	return parsed.isValid() ? parsed.format("YYYY-MM-DD HH:mm:ss") : time;
+};


### PR DESCRIPTION
## Summary
- Sort Analytics "Recent Requests" rows defensively by their full timestamp descending before rendering
- Show date plus time (`YYYY-MM-DD HH:mm:ss`) instead of only `HH:mm:ss` so 24h windows cannot look out of order around day boundaries
- Add regression tests for request sorting and timestamp display formatting

## Test Plan
- [x] `cd frontend && yarn test src/pages/Analytics/utils.test.ts --run`
- [x] `cd frontend && yarn test --run` — 36 tests passed
- [x] `cd frontend && yarn build` — production build succeeded
