### PR TITLE
ci: fix npm dependency update workflow

### DIFF
--- a/.github/workflows/npm-updates.yml
+++ b/.github/workflows/npm-updates.yml
@@ -35,17 +35,20 @@ jobs:
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
         run: |
+          set -euo pipefail
+
           echo "Installing current frontend dependencies..."
           yarn install
 
           echo "Checking for minor/patch updates..."
           echo "### Frontend Updates" > /tmp/frontend-updates.txt
           echo '```text' >> /tmp/frontend-updates.txt
-          # Run npm-check-updates, update package.json, and capture the output
+          # Run npm-check-updates via Yarn, not npx/npm. npm validates "overrides"
+          # differently from Yarn and can fail with EOVERRIDE for direct deps.
           # -u: upgrade package.json
           # --target minor: only upgrade to minor/patch versions, ignoring major
           # --reject vite: vite is pinned in resolutions and must be updated together with vitest manually
-          npx npm-check-updates -u --target minor --reject vite >> /tmp/frontend-updates.txt || true
+          yarn dlx npm-check-updates -u --target minor --reject vite | tee -a /tmp/frontend-updates.txt
           echo '```' >> /tmp/frontend-updates.txt
 
           echo "Installing updated frontend dependencies to update yarn.lock..."
@@ -56,16 +59,19 @@ jobs:
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
         run: |
+          set -euo pipefail
+
           echo "Installing current backend dependencies..."
           yarn install
 
           echo "Checking for minor/patch updates..."
           echo "### Backend Updates" > /tmp/backend-updates.txt
           echo '```text' >> /tmp/backend-updates.txt
-          # Run npm-check-updates, update package.json, and capture the output
+          # Run npm-check-updates via Yarn, not npx/npm, so package-manager
+          # semantics stay consistent with the Yarn 4 project.
           # -u: upgrade package.json
           # --target minor: only upgrade to minor/patch versions, ignoring major
-          npx npm-check-updates -u --target minor >> /tmp/backend-updates.txt || true
+          yarn dlx npm-check-updates -u --target minor | tee -a /tmp/backend-updates.txt
           echo '```' >> /tmp/backend-updates.txt
 
           echo "Installing updated backend dependencies to update yarn.lock..."
@@ -74,6 +80,9 @@ jobs:
       - name: Check for Changes
         id: check_changes
         run: |
+          # Yarn install-state files are local install metadata, not dependency updates.
+          git restore --worktree frontend/.yarn/install-state.gz backend/.yarn/install-state.gz 2>/dev/null || true
+
           # Check if any package.json or yarn.lock was changed
           if git diff --quiet frontend/package.json frontend/yarn.lock backend/package.json backend/yarn.lock; then
             echo "No dependencies were updated."
@@ -114,3 +123,9 @@ jobs:
           branch: "update-all-deps"
           title: "chore(deps): update npm dependencies (minor/patch)"
           body-path: /tmp/pr_body.txt
+          add-paths: |
+            THIRD-PARTY-NOTICES.md
+            frontend/package.json
+            frontend/yarn.lock
+            backend/package.json
+            backend/yarn.lock

--- a/docs/wiki-intern/entwicklung/build.md
+++ b/docs/wiki-intern/entwicklung/build.md
@@ -67,5 +67,6 @@ Die aktuelle Version wird in `.version` gespeichert (Plain Text, z.B. `v4.3.2`).
 ## Verwandte Seiten
 
 - [Deployment](./deployment.md)
+- [CI-Workflows](./ci-workflows.md)
 - [Setup](./setup.md)
 - [Yarn v4 Migration](../entscheidungen/2026-05-20-yarn-v4-migration.md)

--- a/docs/wiki-intern/entwicklung/ci-workflows.md
+++ b/docs/wiki-intern/entwicklung/ci-workflows.md
@@ -1,0 +1,53 @@
+# CI-Workflows
+
+## Zweck
+
+Diese Seite dokumentiert projektinterne GitHub-Actions-Workflows, die Build-, Prüf- und Wartungsaufgaben automatisieren.
+
+## Wichtige Dateien
+
+| Datei                                   | Zweck                                                                   |
+| --------------------------------------- | ----------------------------------------------------------------------- |
+| `.github/workflows/npm-updates.yml`     | Erstellt automatisierte Dependency-Update-PRs für Frontend und Backend. |
+| `.github/workflows/lint-and-format.yml` | Führt Biome, Vitest und Locale-Sortierung aus.                          |
+| `.github/workflows/docker.yml`          | Baut das Docker-Image und Release-Artefakte.                            |
+| `.github/workflows/json.yml`            | Prüft JSON-Dateien.                                                     |
+
+## NPM Dependency Updates
+
+Der Workflow `NPM Dependency Updates` läuft täglich um Mitternacht und kann manuell per `workflow_dispatch` gestartet werden. Er aktualisiert Frontend- und Backend-Abhängigkeiten nur auf Minor-/Patch-Versionen und erstellt bei Änderungen einen PR gegen `develop`.
+
+Wichtiges Verhalten:
+
+1. Corepack wird aktiviert, damit Yarn 4.15.0 verwendet wird.
+2. `npm-check-updates` wird mit `yarn dlx npm-check-updates` ausgeführt, nicht mit `npx`.
+3. Fehler von `npm-check-updates` dürfen nicht mit `|| true` verschluckt werden. Ein kaputter Update-Lauf soll rot werden statt einen irreführenden PR zu erzeugen.
+4. `.yarn/install-state.gz` ist lokale Installations-Metadaten und darf nicht Bestandteil automatischer Dependency-Update-PRs sein.
+5. Der erzeugte PR soll nur diese Pfade aufnehmen:
+   - `THIRD-PARTY-NOTICES.md`
+   - `frontend/package.json`
+   - `frontend/yarn.lock`
+   - `backend/package.json`
+   - `backend/yarn.lock`
+
+## Warum Yarn statt npx?
+
+Das Projekt nutzt Yarn 4 mit `nodeLinker: node-modules`. Die `package.json`-Dateien enthalten sowohl `resolutions` als auch `overrides` für Security- und Kompatibilitäts-Pins. `npx` verwendet npm-Semantik und kann diese `overrides` anders validieren als Yarn.
+
+Bekanntes Symptom:
+
+```text
+npm error code EOVERRIDE
+npm error Override for postcss@^8.5.12 conflicts with direct dependency
+```
+
+In diesem Fall startet `npm-check-updates` über `npx` nicht zuverlässig. `yarn dlx npm-check-updates` verwendet dagegen die Yarn-Projektsemantik und kann die Updates korrekt ermitteln.
+
+## Verwandte Seiten
+
+- [Build](./build.md)
+- [Setup](./setup.md)
+- [Tests](./tests.md)
+- [Yarn v4 Migration](../entscheidungen/2026-05-20-yarn-v4-migration.md)
+
+_Zuletzt aktualisiert: 2026-06-10_

--- a/docs/wiki-intern/entwicklung/setup.md
+++ b/docs/wiki-intern/entwicklung/setup.md
@@ -74,6 +74,7 @@ Konfiguration: `biome.json` (Root-Ebene, vereinheitlicht für Backend und Fronte
 ## Verwandte Seiten
 
 - [Build](./build.md)
+- [CI-Workflows](./ci-workflows.md)
 - [Tests](./tests.md)
 - [Lokale Entwicklung](./lokale-entwicklung.md)
 - [Yarn v4 Migration](../entscheidungen/2026-05-20-yarn-v4-migration.md)

--- a/docs/wiki-intern/index.md
+++ b/docs/wiki-intern/index.md
@@ -34,6 +34,7 @@ Dieses Wiki dient als Langzeitgedächtnis des Projekts. Es erklärt Architektur,
 - [Lokale Entwicklung](./entwicklung/lokale-entwicklung.md)
 - [Tests](./entwicklung/tests.md)
 - [Build](./entwicklung/build.md)
+- [CI-Workflows](./entwicklung/ci-workflows.md)
 - [Deployment](./entwicklung/deployment.md)
 
 ### Module (Backend)


### PR DESCRIPTION
## Summary
- Run `npm-check-updates` through `yarn dlx` instead of `npx`
- Remove `|| true` so broken dependency update runs fail visibly instead of creating misleading PRs
- Restore Yarn install-state metadata before dependency diff checks
- Restrict the automated dependency PR to package files, lockfiles, and `THIRD-PARTY-NOTICES.md`
- Document the workflow behavior and the `EOVERRIDE` pitfall in the internal wiki

## Root cause
`npx npm-check-updates` uses npm semantics. npm validates `overrides` differently from Yarn and fails in the frontend package with:

```text
npm error code EOVERRIDE
npm error Override for postcss@^8.5.12 conflicts with direct dependency
```

Because the old workflow used `|| true`, the frontend failure was swallowed and the workflow still opened a dependency PR with an empty frontend section.

## Verification
- [x] Reproduced the `npx npm-check-updates --target minor --reject vite` frontend failure locally
- [x] Verified `yarn dlx npm-check-updates --target minor --reject vite` succeeds locally
- [x] Verified `yarn dlx npm-check-updates -u --target minor --reject vite` succeeds and upgrades frontend package metadata
- [x] Verified `yarn dlx npm-check-updates -u --target minor` succeeds for backend package metadata
- [x] Restored package/lock/install-state files after smoke tests so this PR only changes workflow + docs
- [x] `yarn dlx prettier --check .github/workflows/npm-updates.yml docs/wiki-intern/entwicklung/ci-workflows.md docs/wiki-intern/index.md docs/wiki-intern/entwicklung/build.md docs/wiki-intern/entwicklung/setup.md`
- [x] `git diff --check`
