### PR TITLE
ci: disable Yarn age gate for npm updates

### DIFF
--- a/.github/workflows/npm-updates.yml
+++ b/.github/workflows/npm-updates.yml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
+    env:
+      # The scheduled dependency updater intentionally tracks fresh minor/patch
+      # releases. Disable Yarn's 24h npm age gate here so npm-check-updates
+      # cannot select a version that the following yarn install then quarantines.
+      YARN_NPM_MINIMAL_AGE_GATE: "0"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Disable Yarn's npm age gate only for the scheduled/manual npm dependency update workflow.
- This prevents npm-check-updates from selecting fresh minor/patch releases that the following `yarn install` rejects as quarantined.

## Verification
- Confirmed `YARN_NPM_MINIMAL_AGE_GATE=0 yarn config get npmMinimalAgeGate` returns `0`.
- Reproduced the backend `systeminformation` update to `^5.31.9` in a throwaway copy and verified `YARN_ENABLE_IMMUTABLE_INSTALLS=false YARN_NPM_MINIMAL_AGE_GATE=0 yarn install` completes successfully.
